### PR TITLE
Add contributing guideline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ We appreciate all kinds of contributions to this project. This document gives yo
 - A good pull request should refer to the issue and thus to the problem that it should solve. Explain what the pull request does and how it addresses the problem/issue. If you still work on a new feature or a fix, you can open a pull request and mark is as draft. Once you consider the work done, please mark it as ready for review and request a reviewer. We will give feedback and eventually merge the pull request.
 - We enforce consistency of the formatting via automatic style checking. When marking a pull request as ready for review, please make sure that all checks pass successfully.
 - For *small changes*, such as typos, broken links etc., please directly create a pull request.
-- For larger changes, such as the description of new tools, a new chapter etc., please open an issue first. In the issue
+- For larger changes, such as the description of new tools, a new chapter etc., please open an issue first.
 
 ## Licensing of contributed material
 


### PR DESCRIPTION
This PR adds a first version for the contribution guidelines.

Open question:
- Should we mention the acknowledgements/how we acknowledge contributions in here?