### PR TITLE
Allow mixing of ordered and unordered lists

### DIFF
--- a/.mdl.rb
+++ b/.mdl.rb
@@ -26,6 +26,8 @@ exclude_rule 'MD040'
 
 # Enforce dashes as symvol in lists
 rule 'MD004', :style => :dash
+#
+rule 'MD007', :indent => 4
 # Extend line length for text.
 # This will complain for overly wide tables and code blocks.
 rule 'MD013', :line_length => 99999

--- a/.mdl.rb
+++ b/.mdl.rb
@@ -26,7 +26,8 @@ exclude_rule 'MD040'
 
 # Enforce dashes as symvol in lists
 rule 'MD004', :style => :dash
-#
+# Enforce indent with four space characters. This helps with
+# mixing ordered and unordered lists
 rule 'MD007', :indent => 4
 # Extend line length for text.
 # This will complain for overly wide tables and code blocks.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 Material of the Simulation Software Engineering lecture. There are different way how to get an overview:
 
-* Look at `timetable.md`,
-* Look at the `overview.md` files of each chapter / folder,
-* Browse the content through the [course website](https://simulation-software-engineering.github.io/homepage/).
+- Look at `timetable.md`,
+- Look at the `overview.md` files of each chapter / folder,
+- Browse the content through the [course website](https://simulation-software-engineering.github.io/homepage/).
 
 ## Linting
 

--- a/organization/material/challenge_intro_slides.md
+++ b/organization/material/challenge_intro_slides.md
@@ -9,7 +9,7 @@ slideOptions:
 
 <style>
   .reveal strong {
-  font-weight: bold;
+    font-weight: bold;
     color: orange;
   }
   .reveal p {
@@ -95,7 +95,7 @@ Rough workload / grading weights: 25%, 25%, 50%
 
 - Alexander or Benjamin
 - Use exercise blocks and time after lectures for discussions
-  - We both attend all lectures and labs
+    - We both attend all lectures and labs
 - Discuss at least what you plan to contribute
 - Share links etc. to issues and PRs (or tag us)
 

--- a/organization/material/intro_course_slides.md
+++ b/organization/material/intro_course_slides.md
@@ -9,7 +9,7 @@ slideOptions:
 
 <style>
   .reveal strong {
-  font-weight: bold;
+    font-weight: bold;
     color: orange;
   }
   .reveal p {
@@ -30,10 +30,10 @@ slideOptions:
 ## Corona Rules
 
 - We need to check everybody's **3G status** and **registration for contact tracing**
-  - Use hardware cactUS reader for both when entering the room (each session)
-  - The lecture has less than 35 students --> Lecturers need to check --> Please don't enter the room before the lecturers are there (15 mins before session)
-  - Please act accordingly (e.g. fill out paper registration if needed or get tested if needed)
-  - Check out after lecture
+    - Use hardware cactUS reader for both when entering the room (each session)
+    - The lecture has less than 35 students --> Lecturers need to check --> Please don't enter the room before the lecturers are there (15 mins before session)
+    - Please act accordingly (e.g. fill out paper registration if needed or get tested if needed)
+    - Check out after lecture
 - Everybody in audience needs to wear an **FFP2 mask**
 - Keep distance, but please don't spread equally over the large room
 
@@ -53,8 +53,8 @@ slideOptions:
 
 - No (advanced) programming course
 - Learn about all the other things you need to develop research /
-  simulation software (to become a *"Research Software Engineer"*):
-  continuous integration, virtualization, building & packaging, documentation, ...
+    simulation software (to become a *"Research Software Engineer"*):
+    continuous integration, virtualization, building & packaging, documentation, ...
 - Focus on tools for C++ and Python
 - More than a *"3-days software carpentry workshop on Python and git"*
 - Learn how to contribute to large-scale open-source simulation software projects
@@ -67,15 +67,15 @@ slideOptions:
 Two parallel branches:
 
 - **Weekly lectures** (90 mins) and **exercises** (90 mins) to learn and train concepts and tools
-  - Thursdays, 09:45–11:15 and 15:45–17:15
-  - This lecture hall: V38.04
-  - No strict distinction between lecture and exercise
-  - Interactive style (not a theory course)
+    - Thursdays, 09:45–11:15 and 15:45–17:15
+    - This lecture hall: V38.04
+    - No strict distinction between lecture and exercise
+    - Interactive style (not a theory course)
 - **Individual challenge**: contribute to real simulation software :rocket:
-  - List of software candidates: this afternoon
-  - 3 presentations from you (more later)
-  - You get a direct advisor
-  - Use exercise blocks and time after lectures for discussions
+    - List of software candidates: this afternoon
+    - 3 presentations from you (more later)
+    - You get a direct advisor
+    - Use exercise blocks and time after lectures for discussions
 
 ---
 
@@ -92,7 +92,7 @@ Two parallel branches:
 - GitHub account
 - We'll create an IPVS-SIM GitLab account for everyone
 - Laptop with root access
-  - You should be able to install and configure software.
+    - You should be able to install and configure software.
 - OK if we use Slido?
 - Signed up on C@MPUS?
 
@@ -148,19 +148,19 @@ Two parallel branches:
 
 <style>
 td {
-  font-size: 35px
+    font-size: 35px
 }
 </style>
 
 | Date | Type | Chapter | Topic | Lecturer |
 | ---- | ---- | ------- |------ | -------- |
 | 21.10. |Lecture | 1-2 | Course intro, intro to SSE, VC basics | Benjamin |
-| 21.10. |Lecture | 2 | Git: my workflow + quiz, software projects for challenge  | Benjamin |
+| 21.10. |Lecture | 2 | Git: my workflow + quiz, software projects for challenge    | Benjamin |
 | 28.10. |Lecture + presentations| 2 | *"My neat little Git trick"*, merge vs rebase, working in teams| Benjamin |
-| 28.10. |Lab | 2 | *"Git cheat sheet"*  | Benjamin |
+| 28.10. |Lab | 2 | *"Git cheat sheet"*    | Benjamin |
 | 04.11. |Lecture | 3 | Virtualbox, Vagrant | Alexander |
 | 04.11. |Lecture | 3 | Docker, Singularity | Alexander |
-| 11.11. |Lab | 3 | tbd.  | Alexander |
+| 11.11. |Lab | 3 | tbd.    | Alexander |
 | 11.11. |Presentations | C | **1st student presentations** | students|
 
 ---
@@ -169,7 +169,7 @@ td {
 
 <style>
 td {
-  font-size: 35px
+    font-size: 35px
 }
 </style>
 
@@ -192,7 +192,7 @@ td {
 
 <style>
 td {
-  font-size: 35px
+    font-size: 35px
 }
 </style>
 
@@ -215,9 +215,9 @@ td {
 
 - *"Course accompanying examination"*: no exam, but continuous examination (more like a lab course or a seminar)
 - We look at:
-  - Challenge (outcome and presentations)
-  - Exercises (not every detail, but *"passed"* or *"failed"*)
-  - Overall engagement (interactive lecture, discussions, small presentations, ...)
+    - Challenge (outcome and presentations)
+    - Exercises (not every detail, but *"passed"* or *"failed"*)
+    - Overall engagement (interactive lecture, discussions, small presentations, ...)
 - Let us know if you cannot come to a lecture / exercise (you don't have to give a reason)
 - You will need to register yourself to the *"exam"* on C@MPUS
 - Point of no return: once you gave the first presentation (Nov 11), you have to register (please let us still know when you drop just before the presentation)
@@ -227,7 +227,7 @@ td {
 ## GitLab Account
 
 - Please write a mail till tonight to Alexander
-  - [alexander.jaust@ipvs.uni-stuttgart.de](mailto:alexander.jaust@ipvs.uni-stuttgart.de)
+    - [alexander.jaust@ipvs.uni-stuttgart.de](mailto:alexander.jaust@ipvs.uni-stuttgart.de)
 - Email subject: "GitLab account SSE course"
 - State your **name** and preferred **email-address**
 - If you already have an IPVS-SIM GitLab account, we only need your username

--- a/organization/material/organizational_remarks_week3_slides.md
+++ b/organization/material/organizational_remarks_week3_slides.md
@@ -41,16 +41,16 @@ slideOptions:
 
 - Please add presentations from last week to [*"My neat little Git trick"*](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/version-control/overview.md#my-favorite-neat-little-Git-trick)
 - [GitHub Universe](https://www.githubuniverse.com/2021) was last week.
-  - Amazing new feature: `ctrl` + `k` and never use mouse again
+    - Amazing new feature: `ctrl` + `k` and never use mouse again
 
 ---
 
 ## Git Cheat Sheet
 
 - Observations:
-  - Pay more attention to descriptions of issues and PRs: what, why, how, ...
-  - As reviewer, don't just accept, but think about how to increase quality
-  - You don't seem to like perfect linear histories :grin: ... in many cases just use `rebase & merge` or `squash & merge` button on GitHub
+    - Pay more attention to descriptions of issues and PRs: what, why, how, ...
+    - As reviewer, don't just accept, but think about how to increase quality
+    - You don't seem to like perfect linear histories :grin: ... in many cases just use `rebase & merge` or `squash & merge` button on GitHub
 - **Deadline**: next Monday, Nov 8, 9am
 
 ---
@@ -59,6 +59,6 @@ slideOptions:
 
 - Have you seen **matching** on [GitLab](https://gitlab-sim.informatik.uni-stuttgart.de/simulation-software-engineering/challenge/-/issues/1)?
 - Information on **first presentations** also on [GitLab](https://gitlab-sim.informatik.uni-stuttgart.de/simulation-software-engineering/challenge/-/issues/2)
-  - Half of students present first step, the other half second step (everybody third step)
-  - Still, everybody needs to hand in a report each time
-  - Please let us know (as early as possible) if you drop out such that we can find another presenter
+    - Half of students present first step, the other half second step (everybody third step)
+    - Still, everybody needs to hand in a report each time
+    - Please let us know (as early as possible) if you drop out such that we can find another presenter

--- a/organization/material/rse_basics_slides.md
+++ b/organization/material/rse_basics_slides.md
@@ -9,7 +9,7 @@ slideOptions:
 
 <style>
   .reveal strong {
-  font-weight: bold;
+    font-weight: bold;
     color: orange;
   }
   .reveal p {
@@ -73,7 +73,7 @@ slideOptions:
 - Yes. Research also happens in industry.
 - All things we learn (Git, packaging, CI/CD, virtualization, documentation, ...) is also highly relevant for non-research software.
 - Companies use (more and more) the same workflows and tools.
-  - It is not just about coding. It is about collaborative work.
+    - It is not just about coding. It is about collaborative work.
 - Open-source development excellent door opener for industry.
 - Some companies develop their software as open-source software.
 

--- a/version-control/material/intro_slides.md
+++ b/version-control/material/intro_slides.md
@@ -8,19 +8,19 @@ slideOptions:
 ---
 
 <style>
-  .reveal strong {
-  font-weight: bold;
-    color: orange;
-  }
-  .reveal p {
-    text-align: left;
-  }
-  .reveal section h1 {
-    color: orange;
-  }
-  .reveal section h2 {
-    color: orange;
-  }
+    .reveal strong {
+      font-weight: bold;
+      color: orange;
+    }
+    .reveal p {
+      text-align: left;
+    }
+    .reveal section h1 {
+      color: orange;
+    }
+    .reveal section h2 {
+      color: orange;
+    }
 </style>
 
 # Introduction to version control
@@ -41,7 +41,7 @@ slideOptions:
 Version control ...
 
 - tracks changes to files and helps people share those changes with each other.
-  - Could also be done via email / Google Docs / ..., but not as accurately and efficiently
+    - Could also be done via email / Google Docs / ..., but not as accurately and efficiently
 - was originally developed for software development, but today cornerstone of *reproducible research*
 
 > "If you can't git diff a file format, it's broken."
@@ -53,8 +53,8 @@ Version control ...
 - *master* (or *main*) copy of code in repository, can't edit directly
 - Instead: check out a working copy of code, edit, commit changes back
 - Repository records complete revision history
-  - You can go back in time
-  - It's clear who did what when
+    - You can go back in time
+    - It's clear who did what when
 
 ---
 
@@ -84,10 +84,10 @@ Distributed version control:
 - Besides remote master version, also local copy of repository
 - More memory required, but much better performance
 - For a long time: highly fragmented market
-  - 2000: BitKeeper (originally proprietary software)
-  - 2005: Mercurial
-  - 2005: Git
-  - A few more
+    - 2000: BitKeeper (originally proprietary software)
+    - 2005: Mercurial
+    - 2005: Git
+    - A few more
 
 Learn more: [Podcast All Things Git: History of VC](https://www.allthingsgit.com/episodes/the_history_of_vc_with_eric_sink.html)
 
@@ -98,7 +98,7 @@ Learn more: [Podcast All Things Git: History of VC](https://www.allthingsgit.com
 No longer a fragmented market, there is nearly only Git today:
 
 - [Stackoverflow developer survey 2021](https://insights.stackoverflow.com/survey/2021#technology-most-popular-technologies):
-  > "Over 90% of respondents use Git, suggesting that it is a fundamental tool to being a developer."
+    > "Over 90% of respondents use Git, suggesting that it is a fundamental tool to being a developer."
 - All software project candidates for *contribution challenge* use Git
 - Is this good or bad?
 

--- a/version-control/material/merge_rebase_slides.md
+++ b/version-control/material/merge_rebase_slides.md
@@ -9,7 +9,7 @@ slideOptions:
 
 <style>
   .reveal strong {
-  font-weight: bold;
+    font-weight: bold;
     color: orange;
   }
   .reveal p {
@@ -41,12 +41,12 @@ slideOptions:
 <img src="https://raw.githubusercontent.com/Simulation-Software-Engineering/Lecture-Material/main/version-control/material/figs/history_linear/fig.png" width=60%; style="margin-left:auto; margin-right:auto; padding-top: 25px; padding-bottom: 25px">
 
 - Commits are snapshots + pointer to parent, not diffs
-  - But for linear history, this makes no difference
+    - But for linear history, this makes no difference
 - Each normal commit has one parent commit
-  - `c05f017^` <-- `c05f017`
-  - `A` = `B^` <-- `B`
-  - (`^` is the same as `~1`)
-  - Pointer to parent commit goes into hash
+    - `c05f017^` <-- `c05f017`
+    - `A` = `B^` <-- `B`
+    - (`^` is the same as `~1`)
+    - Pointer to parent commit goes into hash
 - `git show` gives diff of commit to parent
 
 ---
@@ -55,14 +55,14 @@ slideOptions:
 
 
 - `git checkout main && git merge feature`
-  <img src="https://raw.githubusercontent.com/Simulation-Software-Engineering/Lecture-Material/main/version-control/material/figs/history_merge/fig.png" width=70%; style="margin-left:auto; margin-right:auto; padding-top: 25px; padding-bottom: 25px" >
+    <img src="https://raw.githubusercontent.com/Simulation-Software-Engineering/Lecture-Material/main/version-control/material/figs/history_merge/fig.png" width=70%; style="margin-left:auto; margin-right:auto; padding-top: 25px; padding-bottom: 25px" >
 - A merge commit (normally) has two parent commits `M^1` and `M^2` (don't confuse `^2` with `~2`)
-  - Can't show unique diff
-  - First parent relative to the branch you are on (`M^1` = `C`, `M^2` = `E`)
+    - Can't show unique diff
+    - First parent relative to the branch you are on (`M^1` = `C`, `M^2` = `E`)
 - `git show`
-  - `git show`: *"combined diff"*
-  - GitHub: `git show --first-parent`
-  - `git show -m`: separate diff to all parents
+    - `git show`: *"combined diff"*
+    - GitHub: `git show --first-parent`
+    - `git show -m`: separate diff to all parents
 
 ---
 
@@ -76,7 +76,7 @@ We use here:
 - A merge takes all commits from `feature` to `main` (on `git log`) --> hard to understand
 - Developers often follow projects by reading commits (reading the diffs) --> harder to read (where happened what)
 - Tracing bugs easier with linear history (see `git bisect`)
-  - Example: we know a bug was introduced between `v1.3` and `v1.4`
+    - Example: we know a bug was introduced between `v1.3` and `v1.4`
 
 ---
 
@@ -91,7 +91,7 @@ We use here:
 ## Rebase
 
 - `git checkout feature && git rebase main`
-  <img src="https://raw.githubusercontent.com/Simulation-Software-Engineering/Lecture-Material/main/version-control/material/figs/history_rebase/fig.png" width=90%; style="margin-left:auto; margin-right:auto; padding-top: 25px; padding-bottom: 25px">
+    <img src="https://raw.githubusercontent.com/Simulation-Software-Engineering/Lecture-Material/main/version-control/material/figs/history_rebase/fig.png" width=90%; style="margin-left:auto; margin-right:auto; padding-top: 25px; padding-bottom: 25px">
 - New parents --> new hashes --> history is rewritten
 - If `feature` is already on remote, it needs a force push `git push --force myfork feature`
 - Be careful: only use rebase if **only you** work on a branch (a local branch or a branch on your fork)
@@ -102,9 +102,9 @@ We use here:
 ## GitHub PR Merge Variants
 
 - GitHub offers three ways to merge a non-conflicting (no changes in same files) PR:
-  - Create a merge commit
-  - Squash and merge
-  - Rebase and merge
+    - Create a merge commit
+    - Squash and merge
+    - Rebase and merge
 - Look at a PR together, e.g. [this one](https://github.com/precice/precice/pull/986) (will be closed eventually)
 
 > What do the options do?
@@ -114,9 +114,9 @@ We use here:
 ## Squash and Merge
 
 - ... squashes all commits into one
-  - Often, single commits of feature branch are important while developing the feature,
-  - ... but not when the feature is merged
-  - Works well for small feature PRs
+    - Often, single commits of feature branch are important while developing the feature,
+    - ... but not when the feature is merged
+    - Works well for small feature PRs
 - ... also does a rebase (interactively, `git rebase -i`)
 
 ---

--- a/version-control/material/standards_slides.md
+++ b/version-control/material/standards_slides.md
@@ -1,15 +1,15 @@
 ---
 type: slide
 slideOptions:
-  transition: slide
-  width: 1400
-  height: 900
-  margin: 0.1
+    transition: slide
+    width: 1400
+    height: 900
+    margin: 0.1
 ---
 
 <style>
   .reveal strong {
-  font-weight: bold;
+   font-weight: bold;
     color: orange;
   }
   .reveal p {
@@ -41,8 +41,8 @@ slideOptions:
 - GitHub uses standards or conventions
 - Certain files or names trigger certain behavior automatically
 - Many are supported by most forges
-  - **This is good**
-  - Everybody should know them
+    - **This is good**
+    - Everybody should know them
 
 ---
 
@@ -51,17 +51,17 @@ slideOptions:
 Certain files lead to special formatting (normally directly at root of repo):
 
 - `README.md`
-  - Contains meta information / overview / first steps of software
-  - Gets rendered on landing page (and in every folder)
+    - Contains meta information / overview / first steps of software
+    - Gets rendered on landing page (and in every folder)
 - `LICENSE`
-  - Contains software license
-  - Gets rendered on right sidebar, when clicking on license, and on repo preview
+    - Contains software license
+    - Gets rendered on right sidebar, when clicking on license, and on repo preview
 - `CONTRIBUTING.md`
-  - Contains guidelines for contributing
-  - First-time contributors see banner
+    - Contains guidelines for contributing
+    - First-time contributors see banner
 - `CODE_OF_CONDUCT.md`
-  - Contains code of conduct
-  - Creates link on community profile
+    - Contains code of conduct
+    - Creates link on community profile
 
 ---
 

--- a/version-control/material/workflow_slides.md
+++ b/version-control/material/workflow_slides.md
@@ -9,7 +9,7 @@ slideOptions:
 
 <style>
   .reveal strong {
-  font-weight: bold;
+    font-weight: bold;
     color: orange;
   }
   .reveal p {
@@ -54,8 +54,8 @@ slideOptions:
 - Conflicts: fix locally (push not allowed anyway), use `git pull --rebase`
 - **Good for**: small teams, small projects, projects that are anyway reviewed over and over again
 - Example: LaTeX papers
-  - Put each section in separate file
-  - Put each sentence in separate line
+    - Put each section in separate file
+    - Put each sentence in separate line
 
 ---
 
@@ -63,7 +63,7 @@ slideOptions:
 
 - Each feature (or bugfix) in separate branch
 - Push feature branch to remote, use descriptive name
-  - e.g. issue number in name if each branch closes one issue
+    - e.g. issue number in name if each branch closes one issue
 - `main` should never contain broken code
 - Protect direct push to `main`
 - PR (or MR) with review to merge from feature branch to `main`
@@ -78,13 +78,13 @@ slideOptions:
 
 - [Visualization by Vincent Driessen](https://nvie.com/img/git-model@2x.png), from [original blog post in 2010](https://nvie.com/posts/a-successful-git-branching-model/)
 - `main` and `develop`
-  - `main` contains releases as tags
-  - `develop` contains latest features
+    - `main` contains releases as tags
+    - `develop` contains latest features
 - Feature branches created of `develop`, PRs back to `develop`
 - Protect `main` and (possibly) `develop` from direct pushes
 - Dedicated release branches (e.g., `v1.0`) created of `develop`
-  - Tested, fixed, merged to `main`
-  - Afterwards, tagged, merged back to `develop`
+    - Tested, fixed, merged to `main`
+    - Afterwards, tagged, merged back to `develop`
 - Hotfix branches directly of and to `main`
 - **Good for**: software with users, larger teams
 - There is a tool `git-flow`, a wrapper around `git`, e.g. `git flow init` ... but not really necessary IMHO
@@ -96,8 +96,8 @@ slideOptions:
 - Gitflow + feature branches on other forks
 - More control over access rights, distinguish between maintainers and external contributors
 - Should maintainers also use branches on their forks?
-  - Makes overview of branches easier
-  - Distinguish between prototype branches (on fork, no PR), serious enhancements (on fork with PR), joint enhancements (on upstream)
+    - Makes overview of branches easier
+    - Distinguish between prototype branches (on fork, no PR), serious enhancements (on fork with PR), joint enhancements (on upstream)
 - **Good for**: open-source projects with external contributions (used more or less in preCICE)
 
 ---
@@ -105,9 +105,9 @@ slideOptions:
 ## Do Small PRs
 
 - For all workflows, it is better to do small PRs
-  - Easier to review
-  - Faster to merge --> fewer conflicts
-  - Easier to squash
+    - Easier to review
+    - Faster to merge --> fewer conflicts
+    - Easier to squash
 
 ---
 

--- a/version-control/overview.md
+++ b/version-control/overview.md
@@ -23,11 +23,11 @@ Format: poll, picture, demo
 | 15 minutes | poll, picture, demo |
 
 - Expert level poll on git: ask students to estimate their level.
-  - Beginner: I have hardly ever used Git
-  - User: pull, commit, push, status, diff
-  - Developer: fork, branch, merge, checkout
-  - Maintainer: rebase, squash, cherry-pick, bisect
-  - Owner: submodules
+    - Beginner: I have hardly ever used Git
+    - User: pull, commit, push, status, diff
+    - Developer: fork, branch, merge, checkout
+    - Maintainer: rebase, squash, cherry-pick, bisect
+    - Owner: submodules
 
 ![git overview picture from py-rse](https://merely-useful.tech/py-rse/figures/git-cmdline/git-remote.png)
 
@@ -35,12 +35,12 @@ Format: poll, picture, demo
 - incomplete statement `git comm`
 
 - There is a difference between Git and hosting services ([*forges*](https://en.wikipedia.org/wiki/Forge_(software)))
-  - [GitHub](https://github.com/)
-  - [GitLab](https://about.gitlab.com/), open-source, hosted e.g. at [IPVS](https://gitlab-sim.informatik.uni-stuttgart.de)
-  - [Bitbucket](https://bitbucket.org/product/)
-  - [SourceForge](https://sourceforge.net/)
-  - many more
-  - often, more than just hosting, also DevOps
+    - [GitHub](https://github.com/)
+    - [GitLab](https://about.gitlab.com/), open-source, hosted e.g. at [IPVS](https://gitlab-sim.informatik.uni-stuttgart.de)
+    - [Bitbucket](https://bitbucket.org/product/)
+    - [SourceForge](https://sourceforge.net/)
+    - many more
+    - often, more than just hosting, also DevOps
 
 - Give outlook on remainder of Git chapter: *How I work with Git*, quiz, advanced topics (workflows, rebase, standards), *my neat little Git trick*
 
@@ -56,60 +56,60 @@ Starting remarks:
 - Don't use a client if you don't understand the command line `git`
 
 - (1) Look at GitHub
-  - [preCICE repository](https://github.com/precice/precice)
-  - default branch `develop`
-  - fork -> my fork
+    - [preCICE repository](https://github.com/precice/precice)
+    - default branch `develop`
+    - fork -> my fork
 
 - (2) Working directory:
-  - ZSH shell shows git branches
-  - `git remote -v` (I have upstream, myfork, ...)
-  - mention difference between ssh and https (also see GitHub)
-  - get newest changes `git pull upstream develop`
-  - `git log` -> I use special format, see `~/.gitconfig`,
-  - check log on GitHub; explain short hash
-  - `git branch`
-  - `git branch add-demo-feature`
-  - `git checkout add-demo-feature`
+    - ZSH shell shows git branches
+    - `git remote -v` (I have upstream, myfork, ...)
+    - mention difference between ssh and https (also see GitHub)
+    - get newest changes `git pull upstream develop`
+    - `git log` -> I use special format, see `~/.gitconfig`,
+    - check log on GitHub; explain short hash
+    - `git branch`
+    - `git branch add-demo-feature`
+    - `git checkout add-demo-feature`
 
 - (3) First commit
-  - `git status` -> always tells you what you can do
-  - `vi src/action/Action.hpp` -> add `#include "MagicHeader.hpp"`
-  - `git diff`, `git diff src/com/Action.hpp`, `git diff --color-words`
-  - `git status`, `git add`, `git status`
-  - `git commit` -> "Include MagicHeader in Action.hpp"
-  - `git status`, `git log`, `git log -p`, `git show`
+    - `git status` -> always tells you what you can do
+    - `vi src/action/Action.hpp` -> add `#include "MagicHeader.hpp"`
+    - `git diff`, `git diff src/com/Action.hpp`, `git diff --color-words`
+    - `git status`, `git add`, `git status`
+    - `git commit` -> "Include MagicHeader in Action.hpp"
+    - `git status`, `git log`, `git log -p`, `git show`
 
 - (4) Change or revert things
-  - I forgot to add sth: `git reset --soft HEAD~1`, `git status`
-  - `git diff`, `git diff HEAD` because already staged
-  - `git log`
-  - `git commit`
-  - actually all that is nonsense: `git reset --hard HEAD~1`
-  - modify again, all nonsense before committing: `git checkout src/action/Action.hpp`
+    - I forgot to add sth: `git reset --soft HEAD~1`, `git status`
+    - `git diff`, `git diff HEAD` because already staged
+    - `git log`
+    - `git commit`
+    - actually all that is nonsense: `git reset --hard HEAD~1`
+    - modify again, all nonsense before committing: `git checkout src/action/Action.hpp`
 
 - (5) Stash
-  - while working on unfinished feature, I need to change / test this other thing quickly, too lazy for commits / branches
-  - `git stash`
-  - `git stash pop`
+    - while working on unfinished feature, I need to change / test this other thing quickly, too lazy for commits / branches
+    - `git stash`
+    - `git stash pop`
 
 - (6) Create PR
-  - create commit again
-  - preview what will be in PR: `git diff develop..add-demo-feature`
-  - `git push -u myfork add-demo-feature` -> copy link
-  - explain PR template
-  - explain target branch
-  - explain "Allow edits by maintainers"
-  - cancel
-  - my fork -> branches -> delete
+    - create commit again
+    - preview what will be in PR: `git diff develop..add-demo-feature`
+    - `git push -u myfork add-demo-feature` -> copy link
+    - explain PR template
+    - explain target branch
+    - explain "Allow edits by maintainers"
+    - cancel
+    - my fork -> branches -> delete
 
 - (7) Check out someone else's work
-  - have a look at an existing PR, look at all tabs, show suggestion feature
-  - but sometimes we want to really build and try sth out ...
-  - `git remote -v`
-  - `git remote add alex git@github.com:ajaust/precice.git` if I don't have remote already (or somebody else)
-  - `git fetch alex`
-  - `git checkout -t alex/[branch-name]`
-  - I could now also push to `ajaust`'s remote
+    - have a look at an existing PR, look at all tabs, show suggestion feature
+    - but sometimes we want to really build and try sth out ...
+    - `git remote -v`
+    - `git remote add alex git@github.com:ajaust/precice.git` if I don't have remote already (or somebody else)
+    - `git fetch alex`
+    - `git checkout -t alex/[branch-name]`
+    - I could now also push to `ajaust`'s remote
 
 ## Clicker quiz about Git
 

--- a/virtualization-and-containers/material/containers_slides.md
+++ b/virtualization-and-containers/material/containers_slides.md
@@ -10,16 +10,16 @@ slideOptions:
 <style>
   .reveal strong {
   font-weight: bold;
-    color: orange;
+      color: orange;
   }
   .reveal p {
-    text-align: left;
+      text-align: left;
   }
   .reveal section h1 {
-    color: orange;
+      color: orange;
   }
   .reveal section h2 {
-    color: orange;
+      color: orange;
   }
 </style>
 
@@ -34,10 +34,10 @@ slideOptions:
 
 - Container operates in "fenced off" part of the operating system (`namespaces`)
 - Low(er) overhead than virtual machines
-  - Runs on kernel (and libraries) of the host OS
-  - Cheap to start and stop a container
+    - Runs on kernel (and libraries) of the host OS
+    - Cheap to start and stop a container
 - Available features depend on Host
-  - Linux container on Windows or vice versa?
+    - Linux container on Windows or vice versa?
 - Container can be isolated
 
 ---
@@ -48,21 +48,21 @@ slideOptions:
 - Reproducible environments for developing and testing (DevOps)
 - Container hype strongly driven by [Docker](https://www.docker.com/)
 - More and more in science
-  - High-performance computing, "Bring Your Own Environment" (BYOE)
-  - Reproducible research
+    - High-performance computing, "Bring Your Own Environment" (BYOE)
+    - Reproducible research
 
 ---
 
 ## Container Solutions
 
 - Plenty of different container formats
-  - [lxc/lxd](https://linuxcontainers.org/), [Docker](https://www.docker.com/), [Singularity](https://sylabs.io/), [podman](https://podman.io/), [Sarus](https://user.cscs.ch/tools/containers/sarus/)...
+    - [lxc/lxd](https://linuxcontainers.org/), [Docker](https://www.docker.com/), [Singularity](https://sylabs.io/), [podman](https://podman.io/), [Sarus](https://user.cscs.ch/tools/containers/sarus/)...
 - Different solutions with different strengths due to different use cases
-  - (Super-)Userspace
-  - Direct access to hardware (memory, storage, GPUs) vs. encapsulation
-  - Generic or with integration in software ecosystem (e.g. schedulers)
+    - (Super-)Userspace
+    - Direct access to hardware (memory, storage, GPUs) vs. encapsulation
+    - Generic or with integration in software ecosystem (e.g. schedulers)
 - Effort to establish certain standards
-  - [Open Container Initiative (OCI)](https://opencontainers.org/)
+    - [Open Container Initiative (OCI)](https://opencontainers.org/)
 
 ---
 
@@ -70,12 +70,12 @@ slideOptions:
 
 - Docker considers itself safe
 
-  > Applications are safer in containers and Docker provides the strongest default isolation capabilities in the industry
+    > Applications are safer in containers and Docker provides the strongest default isolation capabilities in the industry
 
-  - But so do most others
+    - But so do most others
 - Read the manual
 - Are third-part containers trust worthy?
-  - There have been cases [of malicious images](https://www.trendmicro.com/vinfo/fr/security/news/virtualization-and-cloud/malicious-docker-hub-container-images-cryptocurrency-mining)
+    - There have been cases [of malicious images](https://www.trendmicro.com/vinfo/fr/security/news/virtualization-and-cloud/malicious-docker-hub-container-images-cryptocurrency-mining)
 - Containers isolation from Host depends on container framework
 - Think about **what** you do, **before** you do it
 
@@ -84,11 +84,11 @@ slideOptions:
 ## Summary
 
 - Shares many similarities with VMs, but
-  - Lightweight alternative to VMs
-  - Stricter limitations than VMs
+    - Lightweight alternative to VMs
+    - Stricter limitations than VMs
 - Many different containers solutions
-  - Standardization effort
-  - Choose right container for your use case
+    - Standardization effort
+    - Choose right container for your use case
 
 **Note**: Do not (only) use containers for shipping your software. Not everyone can run/use them.
 

--- a/virtualization-and-containers/material/docker_slides.md
+++ b/virtualization-and-containers/material/docker_slides.md
@@ -10,16 +10,16 @@ slideOptions:
 <style>
   .reveal strong {
   font-weight: bold;
-    color: orange;
+      color: orange;
   }
   .reveal p {
-    text-align: left;
+      text-align: left;
   }
   .reveal section h1 {
-    color: orange;
+      color: orange;
   }
   .reveal section h2 {
-    color: orange;
+      color: orange;
   }
 </style>
 
@@ -34,14 +34,14 @@ slideOptions:
 ## What is Docker? 1/2
 
 - Docker Inc.
-  - Company promoting Docker
+    - Company promoting Docker
 - Docker Desktop
 
-  > Developer productivity tools and a local Kubernetes environment.
+    > Developer productivity tools and a local Kubernetes environment.
 
 - Docker Engine
 
-  > Docker Engine is an open source containerization technology for building and containerizing your applications.
+    > Docker Engine is an open source containerization technology for building and containerizing your applications.
 
 ---
 
@@ -49,15 +49,15 @@ slideOptions:
 
 - Docker Hub
 
-  > Cloud-based application registry and development team collaboration services.
+    > Cloud-based application registry and development team collaboration services.
 
 - Docker Compose
 
-  > Compose is a tool for defining and running multi-container Docker applications.
+    > Compose is a tool for defining and running multi-container Docker applications.
 
 - According to documentation
 
-  > Docker is an open platform for developing, shipping, and running applications.
+    > Docker is an open platform for developing, shipping, and running applications.
 
 - We use definition from documentation.
 
@@ -67,12 +67,12 @@ slideOptions:
 
 - 2010: Docker Inc. founded
 - 2013: First Docker release
-  - Then based on [LXC](https://linuxcontainers.org/)
-  - Released as open source
+    - Then based on [LXC](https://linuxcontainers.org/)
+    - Released as open source
 - 2014: Replaced LXC by own execution environment
 - 2017: [Moby project](https://mobyproject.org/) for open source
 
-  > Moby is an open framework created by Docker to assemble specialized container systems without reinventing the wheel.
+    > Moby is an open framework created by Docker to assemble specialized container systems without reinventing the wheel.
 
 - Nowadays one of the most popular container frameworks/services
 
@@ -91,24 +91,24 @@ slideOptions:
 ## Building Blocks 1/2
 
 - Docker daemon `dockerd`
-  - Controlling instance of containers and reacts to API requests
-  - Server process
+    - Controlling instance of containers and reacts to API requests
+    - Server process
 - Docker client
-  - User interface/tools to interact with, create, manage containers etc. via daemon
-  - That means no direct interaction with containers, images etc.
+    - User interface/tools to interact with, create, manage containers etc. via daemon
+    - That means no direct interaction with containers, images etc.
 - Docker registries
-  - Registries that manage Docker images to be used
+    - Registries that manage Docker images to be used
 
 ---
 
 ## Building Blocks 2/2
 
 - Docker objects
-  - **Images**
-    - Read-only template for creating a container
-    - An image can be based on another image
-  - **Containers**
-    - Runnable instance of an image
+    - **Images**
+        - Read-only template for creating a container
+        - An image can be based on another image
+    - **Containers**
+        - Runnable instance of an image
 
 ---
 
@@ -122,10 +122,10 @@ slideOptions:
 
 ## Connection to Host
 
-- Container communicates via daemon `dockerd` (runs as   root)
+- Container communicates via daemon `dockerd` (runs as     root)
 - Strong isolation (`namespaces` and `cgroups`)
-  - You cannot access Host filesystem by default
-  - Several [mount options](https://docs.docker.com/storage) available
+    - You cannot access Host filesystem by default
+    - Several [mount options](https://docs.docker.com/storage) available
 
 ---
 
@@ -133,14 +133,14 @@ slideOptions:
 
 - Root rights for installation
 - `dockerd` runs as root -> Interaction needs root rights
-  - Prefix commands with `sudo`
-  - Be member of group `docker` (=makes you root), expected by some applications (e.g. `act`)
-  - [Attack surface?!](https://docs.docker.com/engine/security/#docker-daemon-attack-surface)
-    - [Isolate user namespace](https://docs.docker.com/engine/security/userns-remap/)
-    - Use trustworthy containers
+    - Prefix commands with `sudo`
+    - Be member of group `docker` (=makes you root), expected by some applications (e.g. `act`)
+    - [Attack surface?!](https://docs.docker.com/engine/security/#docker-daemon-attack-surface)
+        - [Isolate user namespace](https://docs.docker.com/engine/security/userns-remap/)
+        - Use trustworthy containers
 - Alternatives:
-  - [Rootless mode](https://docs.docker.com/engine/security/rootless/)
-  - Run Docker in a VM
+    - [Rootless mode](https://docs.docker.com/engine/security/rootless/)
+    - Run Docker in a VM
 - Check [security notes](https://docs.docker.com/engine/security/)
 
 ---
@@ -148,33 +148,33 @@ slideOptions:
 ## Useful Commands 1/2
 
 - `docker run OPTIONS`
-  - Run a container
+    - Run a container
 - `docker image ls`
-  - List locally available images
+    - List locally available images
 - `docker pull NAME:TAG`
-  - Pulls an image from registry, `TAG` optional
+    - Pulls an image from registry, `TAG` optional
 - `docker container create IMAGE`
-  - Create container from image
+    - Create container from image
 - `docker container ls`
-  - List running containers
-  - Add `-a` to see all containers
+    - List running containers
+    - Add `-a` to see all containers
 
 ---
 
 ## Useful Commands 2/2
 
 - `docker container start/stop NAME`
-  - Start/stop container
+    - Start/stop container
 - `docker container attach NAME`
-  - Attach to running container
+    - Attach to running container
 - `docker build`
-  - Creates an image from a given Dockerfile
+    - Creates an image from a given Dockerfile
 - `docker cp`
-  - Copy files in/out of container
+    - Copy files in/out of container
 - `docker image history IMAGE`
-  - Show layers of image (including commands)
+    - Show layers of image (including commands)
 - `docker system prune`
-  - Remove all unused objects (images, containers...)
+    - Remove all unused objects (images, containers...)
 - Many commands have similar/same outcome
 
 ---
@@ -188,13 +188,13 @@ Details available in [`overview.md`](https://github.com/Simulation-Software-Engi
 ## Defining and Building own Images 1/2
 
 - Define container in `Dockerfile`
-  - Git-friendly text file
+    - Git-friendly text file
 - Start from base image
-  - Find images on repository such as [DockerHub](https://hub.docker.com/)
+    - Find images on repository such as [DockerHub](https://hub.docker.com/)
 - Extend image by additional layers
-  - Layers are added separately -> Keep number of layers low
-  - Layers are cached
-  - Changed layer requires downstream layers to be recreated
+    - Layers are added separately -> Keep number of layers low
+    - Layers are cached
+    - Changed layer requires downstream layers to be recreated
 - Container (layers) have commit hashes
 
 ---
@@ -235,10 +235,10 @@ Details available in [`overview.md`](https://github.com/Simulation-Software-Engi
 
 - Publication on registry (e.g. [DockerHub](https://hub.docker.com/))
 - `docker build -t ACCOUNT/REPOSITORY[:TAG] .`
-  - Creates image
+    - Creates image
 - `docker push ACCOUNT/REPOSITORY[:TAG]`
-  - Push image to registry (default DockerHub)
-  - Needs account and must be logged in via `docker login`
+    - Push image to registry (default DockerHub)
+    - Needs account and must be logged in via `docker login`
 
 ---
 
@@ -252,9 +252,9 @@ Details available in [`overview.md`](https://github.com/Simulation-Software-Engi
 
 - User ID mapping
 - [Multistage builds](https://docs.docker.com/develop/develop-images/multistage-build/)
-  - Build image by combining layers created from different base images
+    - Build image by combining layers created from different base images
 - [Different mount typs](https://docs.docker.com/storage)
-  - Volumes, bind mount, tmpfs mount
+    - Volumes, bind mount, tmpfs mount
 - [Persisting data](https://docs.docker.com/get-started/05_persisting_data/)
 - [Multi-container apps](https://docs.docker.com/get-started/07_multi_container/)
 - And many more. Check out the [Docker documentation](https://docs.docker.com)

--- a/virtualization-and-containers/material/homework_slides.md
+++ b/virtualization-and-containers/material/homework_slides.md
@@ -9,7 +9,7 @@ slideOptions:
 
 <style>
   .reveal strong {
-  font-weight: bold;
+    font-weight: bold;
     color: orange;
   }
   .reveal p {
@@ -33,12 +33,12 @@ slideOptions:
 
 - **Deadline**: Before exercise on 11 November 2021
 - What to do?
-  - Install VirtualBox and Vagrant
-  - Install Docker on your machine or in a VM
+    - Install VirtualBox and Vagrant
+    - Install Docker on your machine or in a VM
 - Please follow the manuals on the homepage
-  - [VirtualBox](https://www.virtualbox.org/)
-  - [Vagrant](https://www.vagrantup.com/)
-  - [Docker Engine](https://docs.docker.com/engine/)
+    - [VirtualBox](https://www.virtualbox.org/)
+    - [Vagrant](https://www.vagrantup.com/)
+    - [Docker Engine](https://docs.docker.com/engine/)
 
 
 ---
@@ -46,19 +46,19 @@ slideOptions:
 ## VirtualBox and Vagrant
 
 - Install [VirtualBox](https://www.virtualbox.org/) and [Vagrant](https://www.vagrantup.com/)
-  - Verify that the installation was successful by creating the Vagrant example from the lecture:
+    - Verify that the installation was successful by creating the Vagrant example from the lecture:
 
-    - Navigate to a directory of your choice
+        - Navigate to a directory of your choice
 
-    ```bash
-    vagrant init hashicorp/bionic64
-    vagrant up
-    ```
+        ```bash
+        vagrant init hashicorp/bionic64
+        vagrant up
+        ```
 
-    - Go into the VM `vagrant ssh` and verify the content of the `/vagrant` directory.
-    - Check in the VirtualBox manager that the VM is active.
-    - Leave the SSH session (type `exit` and press `Enter` or use the shortcut `CTRL+D`)
-    - Destroy the VM `vagrant destroy`
+        - Go into the VM `vagrant ssh` and verify the content of the `/vagrant` directory.
+        - Check in the VirtualBox manager that the VM is active.
+        - Leave the SSH session (type `exit` and press `Enter` or use the shortcut `CTRL+D`)
+        - Destroy the VM `vagrant destroy`
 
 **Note**: Please install Vagrant from the homepage so that it is not too old.
 
@@ -67,18 +67,18 @@ slideOptions:
 ## Install Docker
 
 - Install [Docker Engine](https://docs.docker.com/engine/)
-  - You can install it on your machine or in a VM
-  - Check that your installation successful by running
+    - You can install it on your machine or in a VM
+    - Check that your installation successful by running
 
-  ```bash
-  docker run hello-world
-  ```
+    ```bash
+    docker run hello-world
+    ```
 
-    You might have to prefix a `sudo` command. This depends on your Docker configuration.
+      You might have to prefix a `sudo` command. This depends on your Docker configuration.
 
-  - You should see a message that starts with
+    - You should see a message that starts with
 
-  ```bash
-  Hello from Docker!
-  This message shows that your installation appears to be working correctly
-  ```
+    ```bash
+    Hello from Docker!
+    This message shows that your installation appears to be working correctly
+    ```

--- a/virtualization-and-containers/material/intro_slides.md
+++ b/virtualization-and-containers/material/intro_slides.md
@@ -9,7 +9,7 @@ slideOptions:
 
 <style>
   .reveal strong {
-  font-weight: bold;
+    font-weight: bold;
     color: orange;
   }
   .reveal p {
@@ -40,17 +40,17 @@ slideOptions:
 ## Virtualization and Containers for SSE
 
 - Developing, testing and debugging software
-  - Abstraction layer for different OS, configurations etc.
-  - Ensure software quality
+    - Abstraction layer for different OS, configurations etc.
+    - Ensure software quality
 - Moving/Sharing software
-  - Avoid compilation and/or setup complexity, OS dependency
-  - Work around target limitations (e.g. HPC)
+    - Avoid compilation and/or setup complexity, OS dependency
+    - Work around target limitations (e.g. HPC)
 - Manage complex workflows
-  - Ideally under version control
-  - (Potentially) Break down big software into smaller
+    - Ideally under version control
+    - (Potentially) Break down big software into smaller
 - Reproducible research
-  - Make sure others get the same results
-  - Make sure others are able to run your software (also in future)
+    - Make sure others get the same results
+    - Make sure others are able to run your software (also in future)
 - Focus on established, open-source software
 
 ---
@@ -58,8 +58,8 @@ slideOptions:
 ## Contents of this Chapter
 
 - Virtual Machines
-  - VirtualBox: Popular hypervisor for running VMs
-  - Vagrant: Popular management system for VMs (and more)
+    - VirtualBox: Popular hypervisor for running VMs
+    - Vagrant: Popular management system for VMs (and more)
 - Containers
-  - Docker: Popular container framework (and more)
-  - Singularity: Popular scientific container framework
+    - Docker: Popular container framework (and more)
+    - Singularity: Popular scientific container framework

--- a/virtualization-and-containers/material/singularity_slides.md
+++ b/virtualization-and-containers/material/singularity_slides.md
@@ -35,29 +35,29 @@ slideOptions:
 
 - Initiated at Lawrence Berkeley National Laboratory
 - Now: Developed by [Sylabs](https://sylabs.io)
-- Written in  Go
+- Written in    Go
 - Comes in [different flavors](https://sylabs.io/singularity/)
-  - SingularityCE (Community edition, open source, BSD licensed)
-  - SingularityPro (Enterprise)
-  - Singularity Enterprise (More enterprise?)
-  - SingularityDesktop (Mac, Beta)
-  - [Sylabs Cloud](https://cloud.sylabs.io/library)
-    - Image registry and remote builder
-  - [Singularity Hub](https://singularityhub.github.io)
-    - Open source registry
+    - SingularityCE (Community edition, open source, BSD licensed)
+    - SingularityPro (Enterprise)
+    - Singularity Enterprise (More enterprise?)
+    - SingularityDesktop (Mac, Beta)
+    - [Sylabs Cloud](https://cloud.sylabs.io/library)
+        - Image registry and remote builder
+    - [Singularity Hub](https://singularityhub.github.io)
+        - Open source registry
 
 ---
 
 ## Goals
 
 - Verifiable reproducibility and security
-  - Immutable images with encryption and verification support
+    - Immutable images with encryption and verification support
 - Integration over isolation by default
-  - Access hardware (GPU, network...) and filesystems
+    - Access hardware (GPU, network...) and filesystems
 - Simple and effective security model
-  - Same user inside and outside container
+    - Same user inside and outside container
 - "Mobility of Compute"
-  - Single file container for easy transport and sharing
+    - Single file container for easy transport and sharing
 
 ---
 
@@ -66,11 +66,11 @@ slideOptions:
 - Only needs root when creating images
 - User rights for running container
 - Automatically mounts [common directories](https://sylabs.io/guides/latest/user-guide/bind_paths_and_mounts.html#system-defined-bind-paths)
-  - `${HOME}`, `${PWD}`, network etc.
+    - `${HOME}`, `${PWD}`, network etc.
 - Allows to run "untrusted user to run untrusted containers"
-  - Important for shared facilities (computing centers etc.)
+    - Important for shared facilities (computing centers etc.)
 - (Normally) Immutable containers
-  - Set up environment and immutable data in container
+    - Set up environment and immutable data in container
 - Support for typical HPC environments (schedulers, MPI, GPU...)
 
 ---
@@ -80,7 +80,7 @@ slideOptions:
 - Bring Your Own Environment
 - Reproducible research
 - Software needs specific environment
-  - Legacy code, commercial software, unmaintained research software
+    - Legacy code, commercial software, unmaintained research software
 - "Hiding" complicated software stack
 - Conservation of (complicated) workflows
 
@@ -89,16 +89,16 @@ slideOptions:
 ## Useful Commands
 
 - `singularity exec`
-  - Execute a command within container
+    - Execute a command within container
 - `singularity run`
-  - Launch a runscript within container
+    - Launch a runscript within container
 - `singularity shell`
-  - Run a Bourne shell within container
+    - Run a Bourne shell within container
 - `singularity build`
-  - Build a new Singularity container
-  - Use `--sandbox` for mutable container
+    - Build a new Singularity container
+    - Use `--sandbox` for mutable container
 - `singularity pull`
-  - Pull a Singularity/Docker container to ${PWD}
+    - Pull a Singularity/Docker container to ${PWD}
 
 ---
 
@@ -111,16 +111,16 @@ Details available in [`overview.md`](https://github.com/Simulation-Software-Engi
 ## Defining and Building own Images
 
 - Build instructions in text file
-  - Git friendly
+    - Git friendly
 - Start from base images
-  - Several bootstrap strategies (container sources)
-  - Images can be based on Docker images
+    - Several bootstrap strategies (container sources)
+    - Images can be based on Docker images
 - Extra steps
-  - `%post`: Steps after OS installation
-  - `%environment`: Set environment variables (`PATH` etc.)
-  - `%runscript`: Container behavior under `singularity run`
-  - `%labels`: Extra information
-  - `%pre`, `%setup`... (see [Documentation](https://sylabs.io/guides/master/user-guide/definition_files.html#sections))
+    - `%post`: Steps after OS installation
+    - `%environment`: Set environment variables (`PATH` etc.)
+    - `%runscript`: Container behavior under `singularity run`
+    - `%labels`: Extra information
+    - `%pre`, `%setup`... (see [Documentation](https://sylabs.io/guides/master/user-guide/definition_files.html#sections))
 
 ---
 
@@ -131,18 +131,18 @@ BootStrap: library
 From: ubuntu:18.04
 
 %post
-    apt-get -y update
-    apt-get -y install date cowsay lolcat
+        apt-get -y update
+        apt-get -y install date cowsay lolcat
 
 %environment
-    export LC_ALL=C
-    export PATH=/usr/games:$PATH
+        export LC_ALL=C
+        export PATH=/usr/games:$PATH
 
 %runscript
-    date | cowsay | lolcat
+        date | cowsay | lolcat
 
 %labels
-    Author Sylabs
+        Author Sylabs
 ```
 
 [https://sylabs.io/guides/master/user-guide/quick_start.html#build-images-from-scratch](https://sylabs.io/guides/master/user-guide/quick_start.html#build-images-from-scratch)
@@ -159,12 +159,12 @@ Details available in [`overview.md`](https://github.com/Simulation-Software-Engi
 
 - Run container as service (called `instance`)
 - Parallel computing
-  - Using correct MPI, network drivers
-  - MPI: hybrid model, bind model
+    - Using correct MPI, network drivers
+    - MPI: hybrid model, bind model
 - Mounting additional directories
 - Signing, sharing and sandbox containers
 - Performance vs. Portability
-  - Compile content with `arch=generic` or `arch=TARGET`?
+    - Compile content with `arch=generic` or `arch=TARGET`?
 
 ---
 

--- a/virtualization-and-containers/material/slides.md
+++ b/virtualization-and-containers/material/slides.md
@@ -23,20 +23,20 @@ slideOptions:
 ![A sketch of containers](container-sketch.png)
 
 - What is virtualization and what is containerization?
-  - What problems do they solve? Why do we need them?
+    - What problems do they solve? Why do we need them?
 - What are the differences between VMs and containers?
-  - Virtual machines (VWs)
-    - Emulating a complete computer.
-    - Has a (type 1/2) hypervisor. Type 1 runs on bare metal while type 2 runs within an operating system. Distinction not always clear.
-    - Might need/benefit from virtualization technologies (VT-X)
-    - Great flexibility. Can run (normally) any operating system that runs on the virtualized platform.
-    - Strict separation from host operating system. (Popular for safety critical tasks: c't banking os, Desinfec't, Remote laptops)
-  - Containers
-    - Low(er) overhead than virtual machines.
-    - Container operates in "fenced off" part of the operating system (`cgroups`).
-    - Container runs kernel of the host OS.
-    - Operating system (OS) needs to be compatible with underlying OS. Cannot run different OS than host. (TODO: Verify this)
-      - **Note**: Windows 10 can run Linux containers! (Due to Windows Subsystem for Linux?!)
+    - Virtual machines (VWs)
+        - Emulating a complete computer.
+        - Has a (type 1/2) hypervisor. Type 1 runs on bare metal while type 2 runs within an operating system. Distinction not always clear.
+        - Might need/benefit from virtualization technologies (VT-X)
+        - Great flexibility. Can run (normally) any operating system that runs on the virtualized platform.
+        - Strict separation from host operating system. (Popular for safety critical tasks: c't banking os, Desinfec't, Remote laptops)
+    - Containers
+        - Low(er) overhead than virtual machines.
+        - Container operates in "fenced off" part of the operating system (`cgroups`).
+        - Container runs kernel of the host OS.
+        - Operating system (OS) needs to be compatible with underlying OS. Cannot run different OS than host. (TODO: Verify this)
+            - **Note**: Windows 10 can run Linux containers! (Due to Windows Subsystem for Linux?!)
 - Focus will be on Linux and Linux-based containers and VMs.
 - Various virtualization and container technologies and tools to manage them. Sometimes separation is a bit vague/complicated and changed over time (lxc/lxd, Docker).
 - We discuss tools that are (more) likely to be encountered in simulation software.
@@ -49,15 +49,15 @@ slideOptions:
 
 - Big variety of solutions Kernel-based Virtual Machine (KVM)
 - Short background story
-  - Created by Innotek (Weinstadt, Germany! That is close to Stuttgart) and obtained by Sun Microsystems in 2008. Since 2010, owned by Oracle.
+    - Created by Innotek (Weinstadt, Germany! That is close to Stuttgart) and obtained by Sun Microsystems in 2008. Since 2010, owned by Oracle.
 - Initially closed source product with special license for personal use and evaluation (PUEL). Now: Open Source edition which is free, open-source virtual machine solution (GPL2).
 - Discuss some additional foundations of virtualization technologies.
 - Virtual machines are based on virtual disks (VDI) which are virtual hard drives. Might be static or dynamic in size. Makes it possible to move virtual machines easily around.
 - You can have root rights inside your virtual machine.
 - VM will obtain exclusive access to some of your
 - What problems does it solve?
-  - You want to run a different operating system within your current one. Example: I am on Linux, but want to use Microsoft Office and other stuff (without using WINE/Proton).
-  - You want to run services in an encapsulated way. Want to run than one server on one physical machine. (Proxmox, KVM)
+    - You want to run a different operating system within your current one. Example: I am on Linux, but want to use Microsoft Office and other stuff (without using WINE/Proton).
+    - You want to run services in an encapsulated way. Want to run than one server on one physical machine. (Proxmox, KVM)
 - Short question: What type of hypervisor is VirtualBox? Type 2
 
 
@@ -68,13 +68,13 @@ slideOptions:
 | 15 minutes | Demo |
 
 - Discuss configuration:
-  - Virtual machine will reserve cores/threads of your CPU and main memory.
+    - Virtual machine will reserve cores/threads of your CPU and main memory.
 - Maybe go through installation process to show that it is the same as installing an OS on your normal computer.
 - Boot up some virtual machine.
 - Show/install extensions to allow for
-  - Some 3D rendering
-  - Shared clipboard
-  - In general: *Better integration* into host system
+    - Some 3D rendering
+    - Shared clipboard
+    - In general: *Better integration* into host system
 - Create a shared drive to exchange data instead of copy and pasting file content.
 
 ## Vagrant
@@ -84,9 +84,9 @@ slideOptions:
 | 15 minutes | Slides |
 
 - Short background
-  - Company: HashiCorp
-  - Founder (Hashimoto) has background in DevOps
-  - HashiCorp also develops other container/virtualization management tools like TerraForm
+    - Company: HashiCorp
+    - Founder (Hashimoto) has background in DevOps
+    - HashiCorp also develops other container/virtualization management tools like TerraForm
 - Configure VMs (I think also containers nowadays) conveniently via text files
 - Infrastructure as code (Git lecture: If you cannot use `diff`, it is the wrong format!)
 
@@ -97,7 +97,7 @@ slideOptions:
 | 15 minutes | Demo |
 
 - Fire up and use VirtualBox VM.
-  - Example could be the preCICE Vagrant VM.
+    - Example could be the preCICE Vagrant VM.
 
 ## Recap containers and overview
 
@@ -106,7 +106,7 @@ slideOptions:
 | 10 minutes | Slides |
 
 - Shortly recap what we have learned about containers.
-  - Fenced-off, relies on capabilities of OS etc.
+    - Fenced-off, relies on capabilities of OS etc.
 - LXD/LXC and its container registry [Linux containers](https://linuxcontainers.org/)
 - Short and incomplete overview over container technologies: Docker, Singularity, lxc/lxd, podman...
 
@@ -120,26 +120,26 @@ slideOptions:
 
 - The most popular container framework one finds at the moment
 - Short backstory:
-  - Started as wrapper around lxc/lxd (Linux' native container format)
+    - Started as wrapper around lxc/lxd (Linux' native container format)
 - Docker, Docker Engine, Docker Compose, Docker Hub? What is going on?
 - Quite strong encapsulation from Host (**TODO**: Check for file exchange, networking etc.)
 - Common commands:
-  - TODO
+    - TODO
 - Explain text-based format (infrastructure as code)
 
-  ```Dockerfile
-  # Example taken from https://github.com/carlossg/docker-maven
-  FROM openjdk:7-jdk-alpine
+    ```Dockerfile
+    # Example taken from https://github.com/carlossg/docker-maven
+    FROM openjdk:7-jdk-alpine
 
-  RUN apk add --no-cache curl tar bash
-  ```
+    RUN apk add --no-cache curl tar bash
+    ```
 
 - One can pre-build own images to reuse them later.
 - Has a layer based build process (which is nice).
 - Images can be shared via DockerHub
 - Building an image can be pain in the neck as it depends on a fast internet connection.
 - Installation issue/security risks: Docker user group is basically root
-  - Rootless installation of Docker
+    - Rootless installation of Docker
 
 ## Docker practical example
 
@@ -148,7 +148,7 @@ slideOptions:
 | 15 minutes | Demo |
 
 - Write some Dockerfile, build container and run it. Should be a simple container.
-  - Cowsay example? That could be easily reused on the Singularity example.
+    - Cowsay example? That could be easily reused on the Singularity example.
 - Show an existing container. Could be FEniCS or DuMuX.
 
 ## Singularity
@@ -158,22 +158,22 @@ slideOptions:
 | 15 minutes | Slides |
 
 - Back story
-  - Created at Lawrence Berkeley National Laboratory but now developed by SyLabs
-  - Based on Go
+    - Created at Lawrence Berkeley National Laboratory but now developed by SyLabs
+    - Based on Go
 - Container solution with high-performance computing in mind
-  - "Mobility of compute", "Bring your own environment"
-    - Mobility of your compute environment
-    - Normally immutable images
-  - Integration in scheduling systems
-  - Runs in *user-space* (no root privilege escalation)
-  - Direct network and (some) hardware access (GPUs, accelerators)
-  - Mounts common/important directories
-  - Images can be based on Docker images (**TODO** check this). This is nice to prebuild parts of the image as Docker image since Singularity's format is not layer based. This means you have to rebuilt from scratch if it fails.
-  - Small runtime penalty.
+    - "Mobility of compute", "Bring your own environment"
+        - Mobility of your compute environment
+        - Normally immutable images
+    - Integration in scheduling systems
+    - Runs in *user-space* (no root privilege escalation)
+    - Direct network and (some) hardware access (GPUs, accelerators)
+    - Mounts common/important directories
+    - Images can be based on Docker images (**TODO** check this). This is nice to prebuild parts of the image as Docker image since Singularity's format is not layer based. This means you have to rebuilt from scratch if it fails.
+    - Small runtime penalty.
 - Nowadays available on many HPC platforms
 - Show text-based file format. Is similar to Docker
 - Common commands:
-  - TODO
+    - TODO
 
 ## Singularity practical example
 
@@ -182,7 +182,7 @@ slideOptions:
 | 15 minutes | Demo |
 
 - Write some Singularity recipe, build container and run it.
-  - Same example as for Docker?
+    - Same example as for Docker?
 - Show the mounted filesystems and hardware access.
 - Show that we cannot run things as root.
 - (Optional if enoug time): Show Docker and Singulity container side by side

--- a/virtualization-and-containers/material/vagrant_slides.md
+++ b/virtualization-and-containers/material/vagrant_slides.md
@@ -9,7 +9,7 @@ slideOptions:
 
 <style>
   .reveal strong {
-  font-weight: bold;
+    font-weight: bold;
     color: orange;
   }
   .reveal p {
@@ -36,13 +36,13 @@ slideOptions:
 
 - Remember:
 
-  > If you can't git diff a file format, it's broken.
+    > If you can't git diff a file format, it's broken.
 
 - Infrastructure as code
 
-  > Vagrant is a tool for building and managing virtual machine environments in a single workflow.
+    > Vagrant is a tool for building and managing virtual machine environments in a single workflow.
 
-  [https://www.vagrantup.com/intro](https://www.vagrantup.com/intro)
+    [https://www.vagrantup.com/intro](https://www.vagrantup.com/intro)
 - Initial release 2010 by Mitchell Hashimoto, now [HashiCorp](https://www.hashicorp.com/)
 - HashiCorp develops open-source DevOps/Cloud tools like [Vagrant](https://www.vagrantup.com/), [TerraForm](https://www.terraform.io/)...
 
@@ -51,24 +51,24 @@ slideOptions:
 ## Building Blocks
 
 - Provisioners
-  - Tool for configuring the boxes (install software on machine)
-  - Examples: shell scripts, Chef, Puppet..
+    - Tool for configuring the boxes (install software on machine)
+    - Examples: shell scripts, Chef, Puppet..
 - Providers
-  - "Backend" the box is based on
-  - Examples: VirtualBox, Hyper-V, AWS, Docker...
+    - "Backend" the box is based on
+    - Examples: VirtualBox, Hyper-V, AWS, Docker...
 
 ---
 
 ## What for?
 
 - Developing software
-  - Set up consistent development environment
-  - Share environment with others
+    - Set up consistent development environment
+    - Share environment with others
 - Testing software, workflows...
-  - Disposable environments
-  - Consistent workflows
+    - Disposable environments
+    - Consistent workflows
 - More general
-  - Simple way to setup virtual machine
+    - Simple way to setup virtual machine
 - Reproducible environment
 
 ---
@@ -78,41 +78,41 @@ slideOptions:
 - Strong focus on workflow consistency
 - (Re)use existing images
 - Automatize VM creation and configuration
-  - Easier than with VirtualBox CLI and shell scripts
+    - Easier than with VirtualBox CLI and shell scripts
 - Store in Git-friendly format
 - For us:
-  - Management of VirtualBox VMs (testing, developing...)
-  - Sharing of VMs (debugging, workshops...)
+    - Management of VirtualBox VMs (testing, developing...)
+    - Sharing of VMs (debugging, workshops...)
 
 ---
 
 ## Some Useful Commands 1/2
 
 - `vagrant init USERNAME/BOXNAME or URL`
-  - Initializes repository in current directory
-  - Creates `Vagrantfile` -> Text file (Git friendly)
+    - Initializes repository in current directory
+    - Creates `Vagrantfile` -> Text file (Git friendly)
 - `vagrant up`
-  - Create VM and start it
-  - VM is stored in `${HOME}/.vagrant.d/boxes` (overruled by `VAGRANT_HOME`)
+    - Create VM and start it
+    - VM is stored in `${HOME}/.vagrant.d/boxes` (overruled by `VAGRANT_HOME`)
 - `vagrant ssh`
-  - Connect to VM via ssh
+    - Connect to VM via ssh
 - `vagrant destroy`
-  - Stops the virtual machine and removes its disk
+    - Stops the virtual machine and removes its disk
 
 ---
 
 ## Some Useful Commands 2/2
 
 - `vagrant box list`
-  - Show available boxes
+    - Show available boxes
 - `vagrant box remove NAMEOFBOX`
-  - Remove a box completely
+    - Remove a box completely
 - `vagrant suspend`
-  - Suspends machine (sleep)
+    - Suspends machine (sleep)
 - `vagrant halt`
-  - Shuts down machine keeping changes
+    - Shuts down machine keeping changes
 - `vagrant reload --provision` or `vagrant provision`
-  - Rebuild (partially) build image
+    - Rebuild (partially) build image
 
 ---
 
@@ -125,10 +125,10 @@ Details available in [`overview.md`](https://github.com/Simulation-Software-Engi
 ## Structure of Vagrant Box
 
 - File `Vagrantfile`
-  - Contains configuration of VM
-  - Ruby script
+    - Contains configuration of VM
+    - Ruby script
 - Supplementary files, scripts etc. for configuring VM
-  - Example: `bootstrap.sh`
+    - Example: `bootstrap.sh`
 - Files are usually text files (Git friendly)
 
 ---
@@ -139,18 +139,18 @@ Details available in [`overview.md`](https://github.com/Simulation-Software-Engi
 - Install Vagrant (ideally from homepage so it is a recent release)
 - Create `Vagrantfile` and specify image
 
-  ```ruby
-  Vagrant.configure("2") do |config|
-    config.vm.box = "ajaust/sse-first-steps"
-    config.vm.box_version = "0.1.0"
-  end
-  ```
+    ```ruby
+    Vagrant.configure("2") do |config|
+        config.vm.box = "ajaust/sse-first-steps"
+        config.vm.box_version = "0.1.0"
+    end
+    ```
 
 - Alternative:
 
-  ```
-  vagrant init ajaust/sse-first-steps
-  ```
+    ```
+    vagrant init ajaust/sse-first-steps
+    ```
 
 - Start VM with `vagrant up`
 
@@ -159,15 +159,15 @@ Details available in [`overview.md`](https://github.com/Simulation-Software-Engi
 ## Exchanging Files
 
 - Vagrant mounts shared folders
-  - Check output when VM starts
+    - Check output when VM starts
 
-  ```bash
-  default: Mounting shared folders...
-  ```
+    ```bash
+    default: Mounting shared folders...
+    ```
 
-  - Files can be exchanged between Guest and Host (bidirectional)
+    - Files can be exchanged between Guest and Host (bidirectional)
 - Default:
-  - Directory containing `Vagrantfile` mounted to `/vagrant` in Guest
+    - Directory containing `Vagrantfile` mounted to `/vagrant` in Guest
 
 ---
 
@@ -176,12 +176,12 @@ Details available in [`overview.md`](https://github.com/Simulation-Software-Engi
 - Repository of premade boxes: [https://app.vagrantup.com/](https://app.vagrantup.com/)
 - Pack box:
 
-  ```bash
-  vagrant package --base "NAMEOFVM" --output BOXNAME.box
-  ```
+    ```bash
+    vagrant package --base "NAMEOFVM" --output BOXNAME.box
+    ```
 
-  - `NAMEOFVM` is name as shown in VirtualBox
-  - `BOXNAME` name to store box to
+    - `NAMEOFVM` is name as shown in VirtualBox
+    - `BOXNAME` name to store box to
 - [Publish own boxes](https://www.vagrantup.com/docs/providers/virtualbox/boxes) by uploading to [Vagrant Cloud](https://app.vagrantup.com/)
 
 ---

--- a/virtualization-and-containers/material/virtualbox_slides.md
+++ b/virtualization-and-containers/material/virtualbox_slides.md
@@ -10,7 +10,7 @@ slideOptions:
 
 <style>
   .reveal strong {
-  font-weight: bold;
+    font-weight: bold;
     color: orange;
   }
   .reveal p {
@@ -45,10 +45,10 @@ slideOptions:
 
 - Reasonably new operating system (Windows, Mac OS, Linux, Oracle Solaris)
 - Reasonably new hardware (SSE2 and virtualization support)
-  - VT-x, VT-d, AMD-V, ...
-  - Check virtualization settings in BIOS/UEFI if it does not work out of the box
+    - VT-x, VT-d, AMD-V, ...
+    - Check virtualization settings in BIOS/UEFI if it does not work out of the box
 - Sufficient space on hard drive
-  - VM uses a virtual hard drive, i.e., a file on your drive
+    - VM uses a virtual hard drive, i.e., a file on your drive
 - Some video memory (recommend >=64MB)
 - Exact requirements depend on VM
 
@@ -57,10 +57,10 @@ slideOptions:
 ## Virtual Hard Drive Formats
 
 - Main formats
-  - **VDI**: "Virtual Disk Image", VirtualBox' native format
-  - **VHD**: Format used by Microsoft
-  - **VMDK**: VMWare's virtual disk format
-  - Support dynamic allocation
+    - **VDI**: "Virtual Disk Image", VirtualBox' native format
+    - **VHD**: Format used by Microsoft
+    - **VMDK**: VMWare's virtual disk format
+    - Support dynamic allocation
 - Further (partially) supported formats: HDD (Parallels format), QCOW, QED
 
 **Note**: If you use btrfs as filesystem, you should disable CoW for the VM's images. (I/O load)
@@ -80,22 +80,22 @@ slideOptions:
 ## Guest Additions
 
 - Software and drivers to improves Guest's performance
-  - Better video support, shared clipboard, mouse pointer integration...
+    - Better video support, shared clipboard, mouse pointer integration...
 - Might need additional packages
-  - On Ubuntu 20.04
+    - On Ubuntu 20.04
 
-  ```bash
-  sudo apt install virtualbox-guest-dkms virtualbox-guest-x11 virtualbox-guest-utils
-  ```
+    ```bash
+    sudo apt install virtualbox-guest-dkms virtualbox-guest-x11 virtualbox-guest-utils
+    ```
 
-  - `virtualbox-guest-x11` can be dropped on headless system
-  - On Ubuntu for building packages manually
+    - `virtualbox-guest-x11` can be dropped on headless system
+    - On Ubuntu for building packages manually
 
-  ```bash
-  perl dkms build-essential linux-headers-generic linux-headers-$(uname -r)
-  ```
+    ```bash
+    perl dkms build-essential linux-headers-generic linux-headers-$(uname -r)
+    ```
 
-  - Then run installation script of Guest Additions
+    - Then run installation script of Guest Additions
 - Screen black after/during installation -> Increase video memory to >=64 MB
 
 
@@ -114,12 +114,12 @@ Details available in [`overview.md`](https://github.com/Simulation-Software-Engi
 - Offers flexibility on OS choice
 - Manual setup, but also CLI interface exists
 - Next steps
-  - How to manage several VMs efficiently?
+    - How to manage several VMs efficiently?
 
-  > "If you can't git diff a file format, it's broken."
+    > "If you can't git diff a file format, it's broken."
 
-  - Consistency of the environment?
-  - Sharing image with others?
+    - Consistency of the environment?
+    - Sharing image with others?
 
 
 ---

--- a/virtualization-and-containers/material/virtualmachines_slides.md
+++ b/virtualization-and-containers/material/virtualmachines_slides.md
@@ -9,7 +9,7 @@ slideOptions:
 
 <style>
   .reveal strong {
-  font-weight: bold;
+    font-weight: bold;
     color: orange;
   }
   .reveal p {
@@ -39,23 +39,23 @@ slideOptions:
 ## Common Terms
 
 - Host operating system (host OS)
-  - The OS the hypervisor is installed on
+    - The OS the hypervisor is installed on
 - Guest operating system (guest OS)
-  - The OS running inside the virtual machine
+    - The OS running inside the virtual machine
 - Virtual machine (VM)
-  - Environment the guest is running in
+    - Environment the guest is running in
 
 ---
 
 ## Types of Virtual Machines / Hypervisors
 
 - Sometimes distinction not clear, but in general:
-  - **Type 1**
-    - Runs directly on bare-metal hardware
-    - Examples: [Microsoft Hyper-V](https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/about/), [VMware ESXi](https://www.vmware.com/products/esxi-and-esx.html), [Proxmox Virtual Environment](https://www.proxmox.com/en/proxmox-ve), [Xen](https://xenproject.org/)...
-  - **Type 2**
-    - Requires a running OS
-    - Examples: [VirtualBox](https://www.virtualbox.org/), [VMWare Workstation Player](https://www.vmware.com/products/workstation-player.html), [Parallels (for Mac)](https://www.parallels.com/eu/products/desktop/)...
+    - **Type 1**
+        - Runs directly on bare-metal hardware
+        - Examples: [Microsoft Hyper-V](https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/about/), [VMware ESXi](https://www.vmware.com/products/esxi-and-esx.html), [Proxmox Virtual Environment](https://www.proxmox.com/en/proxmox-ve), [Xen](https://xenproject.org/)...
+    - **Type 2**
+        - Requires a running OS
+        - Examples: [VirtualBox](https://www.virtualbox.org/), [VMWare Workstation Player](https://www.vmware.com/products/workstation-player.html), [Parallels (for Mac)](https://www.parallels.com/eu/products/desktop/)...
 
 ---
 
@@ -65,22 +65,22 @@ slideOptions:
 - Behaves (more or less) as native installation (root etc., system calls)
 - (Strict) isolation from host operating system
 - Popular for
-  - Safety critical tasks
-  - Development and testing
-  - Wherever one wants a portable solution
+    - Safety critical tasks
+    - Development and testing
+    - Wherever one wants a portable solution
 
 ---
 
 ## Why is Virtualization Useful?
 
 - Running multiple operating systems simultaneously
-  - Test/develop software for other OS, debug problems on other OS, Windows on Linux, fill in forms of university (MS Office)
+    - Test/develop software for other OS, debug problems on other OS, Windows on Linux, fill in forms of university (MS Office)
 - Easier software installations and testing
-  - Preconfigured VMs trainings and teaching
+    - Preconfigured VMs trainings and teaching
 - Testing and disaster recovery
-  - Create snapshots before testing, copy VMs etc.
+    - Create snapshots before testing, copy VMs etc.
 - Infrastructure consolidation
-  - Run many VMs on single host
+    - Run many VMs on single host
 - Seperate services from each other (security?!)
 - Reproducible software environment for running and developing software
 
@@ -93,7 +93,7 @@ slideOptions:
 - Virtual machine / Hypervisor might increase attack surface
 - Additional layer of complexity
 - Read the manual
-  - Examples: GPU acceleration, networking, USB passthrough...
+    - Examples: GPU acceleration, networking, USB passthrough...
 - Think about **what** you do and **before** you do it
 
 ---

--- a/virtualization-and-containers/overview.md
+++ b/virtualization-and-containers/overview.md
@@ -5,12 +5,12 @@
 | 5 minutes | Slides |
 
 - **Learning goals**
-  - What is the difference between virtualization and containers?
-  - When to use virtual machines and when containers.
-  - How to work with virtual machines (VirtualBox) and how to manage these with Vagrant.
-  - Building containers with Docker and Singularity.
-  - Understand pros and cons of different container technologies.
-  - Student can set up their own containers tailored to their requirements.
+    - What is the difference between virtualization and containers?
+    - When to use virtual machines and when containers.
+    - How to work with virtual machines (VirtualBox) and how to manage these with Vagrant.
+    - Building containers with Docker and Singularity.
+    - Understand pros and cons of different container technologies.
+    - Student can set up their own containers tailored to their requirements.
 
 ## Quiz (optional)
 
@@ -33,14 +33,14 @@
 ![A sketch of containers](container-sketch.png)
 
 - What is virtualization and what is containerization?
-  - What problems do they solve? Why do we need them?
+    - What problems do they solve? Why do we need them?
 - Virtual machines (VWs)
-  - Emulating a complete computer.
-  - Virtual machine brings the full software stack (kernel, libraries etc.)
-  - Has a (type 1/2) hypervisor. Type 1 runs on bare metal while type 2 runs within an operating system. Distinction not always clear.
-  - Might need/benefit from virtualization technologies (VT-X)
-  - Great flexibility. Can run (normally) any operating system that runs on the virtualized platform.
-  - Strict separation from host operating system. (Popular for safety critical tasks: c't banking os, Desinfec't, Remote laptops)
+    - Emulating a complete computer.
+    - Virtual machine brings the full software stack (kernel, libraries etc.)
+    - Has a (type 1/2) hypervisor. Type 1 runs on bare metal while type 2 runs within an operating system. Distinction not always clear.
+    - Might need/benefit from virtualization technologies (VT-X)
+    - Great flexibility. Can run (normally) any operating system that runs on the virtualized platform.
+    - Strict separation from host operating system. (Popular for safety critical tasks: c't banking os, Desinfec't, Remote laptops)
 - Focus of lecture will be on Linux and Linux-based containers and VMs.
 - Various virtualization and container technologies and tools to manage them. Sometimes separation is a bit vague/complicated and changed over time (lxc/lxd, Docker).
 - We discuss tools and use cases that are (more) likely to be encountered in simulation software.
@@ -53,75 +53,75 @@
 
 - You can have root rights inside your virtual machine.
 - What problems does it solve?
-  - You want to run a different operating system within your current one. Example: I am on Linux, but want to use Microsoft Office and other stuff (without using WINE/Proton).
-  - You want to run services in an encapsulated way. Want to run than one server on one physical machine. (Proxmox, KVM)
+    - You want to run a different operating system within your current one. Example: I am on Linux, but want to use Microsoft Office and other stuff (without using WINE/Proton).
+    - You want to run services in an encapsulated way. Want to run than one server on one physical machine. (Proxmox, KVM)
 - Hypervisors create some overhead.
 - Content of a VirtualBox Image
-  - Show directory on drive:
-    - `NAMEOFVM.vdi`: The virtual hard drive containing the guest os
-    - `NAMEOFVM.vbox`: XML containing metadata and configuration information (RAM, network devices...)
-    - `NAMEOFVM.vbox-prev`: Backup of previous settings
-    - `Logs/`: Directory containing log files
-    - `Snapshots/`: Snapshots of image
+    - Show directory on drive:
+        - `NAMEOFVM.vdi`: The virtual hard drive containing the guest os
+        - `NAMEOFVM.vbox`: XML containing metadata and configuration information (RAM, network devices...)
+        - `NAMEOFVM.vbox-prev`: Backup of previous settings
+        - `Logs/`: Directory containing log files
+        - `Snapshots/`: Snapshots of image
 - Short question: What type of hypervisor is VirtualBox? Type 2
 
 
 ### VirtualBox demo
 
 - Discuss configuration:
-  - Virtual machine will reserve cores/threads of your CPU and main memory.
+    - Virtual machine will reserve cores/threads of your CPU and main memory.
 - Maybe go through installation process to show that it is the same as installing an OS on your normal computer.
 - Create a new virtual machine and boot it up (nothing will happen).
 - Boot up some configured virtual machine (Ubuntu).
 - Creating a new virtual machine
-  - Click on `new`
-  - I use `expert mode` to set disk location, size and memory. Note, that one can change that also later on.
-  - After clicking on `Create` a menu to create the `Virtual Hard Disk` opens.
-    - One can choose between fixed size and dynamically allocated (i.e. the drive grows). I personally recommend avoiding dynamically allocated without upper limit.
-  - Creates empty machine. Will not do much as we do not have any OS installed. VirtualBox will prompt to mount an image (iso).
-  - Show system settings of VM.
-  - Storage -> Controller (Mount drive here) and boot again. -> Installation will start up.
-    - Normally should unmount image after installation.
-  - Install "VirtualBox Guest Additions". Might have to download the image.
-    - Devices `Insert Guest Additions CD image"
+    - Click on `new`
+    - I use `expert mode` to set disk location, size and memory. Note, that one can change that also later on.
+    - After clicking on `Create` a menu to create the `Virtual Hard Disk` opens.
+        - One can choose between fixed size and dynamically allocated (i.e. the drive grows). I personally recommend avoiding dynamically allocated without upper limit.
+    - Creates empty machine. Will not do much as we do not have any OS installed. VirtualBox will prompt to mount an image (iso).
+    - Show system settings of VM.
+    - Storage -> Controller (Mount drive here) and boot again. -> Installation will start up.
+        - Normally should unmount image after installation.
+    - Install "VirtualBox Guest Additions". Might have to download the image.
+        - Devices `Insert Guest Additions CD image"
 
-    ```bash
-    sudo mkdir -p /media/cdrom
-    sudo mount /dev/cdrom /media/cdrom
-    cd /media/cdrom
-    sudo apt-get install -y perl dkms build-essential linux-headers-generic linux-headers-$(uname -r)
-    sudo su
-    ./VBoxLinuxAdditions.run
-    ```
+        ```bash
+        sudo mkdir -p /media/cdrom
+        sudo mount /dev/cdrom /media/cdrom
+        cd /media/cdrom
+        sudo apt-get install -y perl dkms build-essential linux-headers-generic linux-headers-$(uname -r)
+        sudo su
+        ./VBoxLinuxAdditions.run
+        ```
 
-    - Will enable clipboard sharing etc
-    - Alternative on Ubuntu
+        - Will enable clipboard sharing etc
+        - Alternative on Ubuntu
 
-    ```bash
-    sudo apt install virtualbox-guest-dkms virtualbox-guest-x11 virtualbox-guest-utils
-    ```
+        ```bash
+        sudo apt install virtualbox-guest-dkms virtualbox-guest-x11 virtualbox-guest-utils
+        ```
 
-    - `virtualbox-guest-x11` can be dropped on headless system
-  - VM will capture mouse pointer. Use `Right-CTRL` to "free" pointer again.
-  - Create snapshots on image overview (Burger symbol on the right)
-    - Load snapshots for different configuration stages
-  - Configure network for ssh
-    - Install `openssh-server`
-    - Shutdown VM
-    - In VirtualBox window -> File -> Host Network Manager -> Verify that network device is configured `vboxnet0`
-    - In virtual machine's settings -> Network -> Adapter 2 -> Enable and set Host only adapter `vboxnet0`
-    - Boot VM
-    - Verify additional network device `enp0s8` and check for ip address. In my case `192.168.56.101`
-    - On host machine `ssh vmuser@192.168.56.101`
+        - `virtualbox-guest-x11` can be dropped on headless system
+    - VM will capture mouse pointer. Use `Right-CTRL` to "free" pointer again.
+    - Create snapshots on image overview (Burger symbol on the right)
+        - Load snapshots for different configuration stages
+    - Configure network for ssh
+        - Install `openssh-server`
+        - Shutdown VM
+        - In VirtualBox window -> File -> Host Network Manager -> Verify that network device is configured `vboxnet0`
+        - In virtual machine's settings -> Network -> Adapter 2 -> Enable and set Host only adapter `vboxnet0`
+        - Boot VM
+        - Verify additional network device `enp0s8` and check for ip address. In my case `192.168.56.101`
+        - On host machine `ssh vmuser@192.168.56.101`
 - Show/install extensions to allow for
-  - Some 3D rendering
-  - Shared clipboard
-  - In general: *Better integration* into host system
+    - Some 3D rendering
+    - Shared clipboard
+    - In general: *Better integration* into host system
 - Create a shared drive to exchange data instead of copy and pasting file content.
-  - In case one cannot access it `sudo usermod -aG vboxsf $(whoami)`
-  - You need to logout and in again afterwards for usergroups to be recognized.
-  - I share `/media/jaustar/external-ssd/virtualmachines/shared-folder`
-  - Add some file there and check that it appears Host and vice versa.
+    - In case one cannot access it `sudo usermod -aG vboxsf $(whoami)`
+    - You need to logout and in again afterwards for usergroups to be recognized.
+    - I share `/media/jaustar/external-ssd/virtualmachines/shared-folder`
+    - Add some file there and check that it appears Host and vice versa.
 
 ## Vagrant (including practical examples)
 
@@ -132,7 +132,7 @@
 - Initially deveoped by Mitchell Hashimoto as side project
 - Released in 2010
 - Now developed by Hashimoto's company HashiCorp
-  - HashiCorp develops a variety of open-source tools for DevOps and cloud computing. In general for large scale projects.
+    - HashiCorp develops a variety of open-source tools for DevOps and cloud computing. In general for large scale projects.
 - Configure VMs (I think also containers nowadays) conveniently via text files
 - Infrastructure as code (Git lecture: If you cannot use `diff`, it is the wrong format!)
 - Standard user and all passwords are `vagrant`
@@ -157,10 +157,10 @@ Tutorial case in `/media/jaustar/external-ssd/virtualmachines/vagrant/tutorial`
 - `vagrant status` Shows status of currently running VMs
 
 - Exchanging files
-  - Check output `default: Mounting shared folders...`
-  - Default: Directory containing `Vagrantfile` is mounted as  `/vagrant`
-  - Can configure more drives
-  - Show example by creating file from Vagrant session
+    - Check output `default: Mounting shared folders...`
+    - Default: Directory containing `Vagrantfile` is mounted as    `/vagrant`
+    - Can configure more drives
+    - Show example by creating file from Vagrant session
 
 ### Demo: Own box
 
@@ -168,64 +168,64 @@ Tutorial case in `/media/jaustar/external-ssd/virtualmachines/vagrant/tutorial`
 - Go to template `cd /media/jaustar/external-ssd/virtualmachines/vagrant/own-box-template`
 - Open `Vagrantfile` and refer to name of VM
 
-  ```ruby
-  Vagrant.configure("2") do |config|
-    config.vm.box = "ubuntu/focal64"
-    config.vm.provision :shell, path: "bootstrap.sh"
+    ```ruby
+    Vagrant.configure("2") do |config|
+        config.vm.box = "ubuntu/focal64"
+        config.vm.provision :shell, path: "bootstrap.sh"
 
-    config.vm.provider "virtualbox" do |vb|
-      vb.name = "sse-first-step"
+        config.vm.provider "virtualbox" do |vb|
+            vb.name = "sse-first-step"
+        end
     end
-  end
-  ```
+    ```
 
 - Open `bootstrap.sh` to show that it will do
 
-  ```bash
-  !/usr/bin/env bash
+    ```bash
+    !/usr/bin/env bash
 
-  apt-get update
-  apt-get install -y neofetch vim
-  echo "export TEST_ENV_VAR=\"Hello SSE\"" >> .bashrc
-  ```
+    apt-get update
+    apt-get install -y neofetch vim
+    echo "export TEST_ENV_VAR=\"Hello SSE\"" >> .bashrc
+    ```
 
-  - Installs software and sets `TEST_ENV_VAR`
+    - Installs software and sets `TEST_ENV_VAR`
 - `vagrant up`: Create VM
-  - Image should be prebuilt
+    - Image should be prebuilt
 - `vagrant ssh`
-  - Call `neofetch`
-  - `echo $TEST_ENV_VAR` to show that variable is actually set.
+    - Call `neofetch`
+    - `echo $TEST_ENV_VAR` to show that variable is actually set.
 - `vagrant package --base "sse-first-step" --output sse-first-step.box`: Export VM
-  - File has ben upladed already
+    - File has ben upladed already
 - `sse-first-steps.box` can be uploaded to [Vagrant Cloud](https://app.vagrantup.com)
 - Go to directory `using-own-box/`
-  - Show `Vagrantfile` that is has my uploaded image as base image
-  - Skip building box `vagrant up` as it takes too long, should be prebuilt
-  - `vagrant box list` shoud show my box in overview.
-  - **Note** My uploaded box is called `ajaust/sse-first-step`**s**
-  - **Note** The box seems to be broken all of a sudden.
+    - Show `Vagrantfile` that is has my uploaded image as base image
+    - Skip building box `vagrant up` as it takes too long, should be prebuilt
+    - `vagrant box list` shoud show my box in overview.
+    - **Note** My uploaded box is called `ajaust/sse-first-step`**s**
+    - **Note** The box seems to be broken all of a sudden.
 
 ### Demo: preCICE VM
 
 - Show repository:
-  - [https://github.com/precice/vm](https://github.com/precice/vm)
+    - [https://github.com/precice/vm](https://github.com/precice/vm)
 - Run [Premade box](https://app.vagrantup.com/precice/boxes/precice-vm)
-  - `cd /media/jaustar/external-ssd/virtualmachines/vagrant/precice`
-  - Create box with `vagrant init` (Done before lecture as it takes to long)
-  - Start box `vagrant up`
-  - Comes with a GUI
-  - Preconfigured
-  - Destroy in the end `vagrant destroy` since it is large (?)
+    - `cd /media/jaustar/external-ssd/virtualmachines/vagrant/precice`
+    - Create box with `vagrant init` (Done before lecture as it takes to long)
+    - Start box `vagrant up`
+    - Comes with a GUI
+    - Preconfigured
+    - Destroy in the end `vagrant destroy` since it is large (?)
 - If time allows, show preCICE example
-  - [Tutorial](https://precice.org/installation-vm.html#how-to-use-this)
-  - [Quickstart](https://precice.org/quickstart.html)
-    - Open two terminals
-    - Go to `/home/vagrant/Desktop/tutorials/quickstart`
-    - In one terminal go to `cpp-solid` and build solver `cmake . && make`
-      - Afterwards start simulation with `./run.sh`
-    - In other terminal go to `fluid-openfoam`
-      - Afterwards start simulation with `./run.sh`
-    - Watch simulation running
+    - [Tutorial](https://precice.org/installation-vm.html#how-to-use-this)
+    - [Quickstart](https://precice.org/quickstart.html)
+        - Open two terminals
+        - Go to `/home/vagrant/Desktop/tutorials/quickstart`
+        - In one terminal go to `cpp-solid` and build solver `cmake . && make`
+            - Afterwards start simulation with `./run.sh`
+        - In other terminal go to `fluid-openfoam`
+            - Afterwards start simulation with `./run.sh`
+        - Watch simulation running
 
 ## Introduction to Containers
 
@@ -234,15 +234,15 @@ Tutorial case in `/media/jaustar/external-ssd/virtualmachines/vagrant/tutorial`
 | 10 minutes | Slides |
 
 - What are the differences between VMs and containers?
-  - Containers
-    - Low(er) overhead than virtual machines.
-    - Container operates in "fenced off" part of the operating system (`cgroups`).
-    - Container runs kernel of the host OS -> Does **not** run its own OS in.
-    - Operating system (OS) needs to be compatible with underlying OS. Cannot run different OS than host. (TODO: Verify this)
-      - **Note**: Windows 10 can run Linux containers! (Due to Windows Subsystem for Linux?!)
-    - A process for which (and its childs) special rules apply.
+    - Containers
+        - Low(er) overhead than virtual machines.
+        - Container operates in "fenced off" part of the operating system (`cgroups`).
+        - Container runs kernel of the host OS -> Does **not** run its own OS in.
+        - Operating system (OS) needs to be compatible with underlying OS. Cannot run different OS than host. (TODO: Verify this)
+            - **Note**: Windows 10 can run Linux containers! (Due to Windows Subsystem for Linux?!)
+        - A process for which (and its childs) special rules apply.
 - Shortly recap what we have learned about containers.
-  - Fenced-off, relies on capabilities of OS etc.
+    - Fenced-off, relies on capabilities of OS etc.
 - LXD/LXC and its container registry [Linux containers](https://linuxcontainers.org/)
 - Short and incomplete overview over container technologies: Docker, Singularity, lxc/lxd, podman...
 
@@ -256,9 +256,9 @@ Tutorial case in `/media/jaustar/external-ssd/virtualmachines/vagrant/tutorial`
 | 5 minutes | Quiz |
 
 - Quiz "What is Docker?"
-  - Start slido quiz
-  - Answer depends on when in time and  you ask.
-    - Containerization framework, container management, company...
+    - Start slido quiz
+    - Answer depends on when in time and    you ask.
+        - Containerization framework, container management, company...
 
 ## Docker (including practical examples)
 
@@ -269,45 +269,45 @@ Tutorial case in `/media/jaustar/external-ssd/virtualmachines/vagrant/tutorial`
 - [`act`](https://github.com/nektos/act) is a tool to debug/run GitHub actions locally
 - The most popular container framework one finds at the moment
 - Short backstory:
-  - Started as wrapper around lxc/lxd (Linux' native container format)
+    - Started as wrapper around lxc/lxd (Linux' native container format)
 - Docker, Docker Engine, Docker Compose, Docker Hub? What is going on?
 - Server-client layout
 - Quite strong encapsulation from Host (**TODO**: Check for file exchange, networking etc.)
 - **Generally useful commands** (see slides as well)
-  - `docker run OPTIONS`
-    - Run a container
-  - `docker image ls`
-    - List locally available images
-  - `docker pull NAME:TAG`
-    - Pulls an image from registry, `TAG` optional
-  - `docker container create IMAGE`
-    - Create container from image
-  - `docker container ls`
-    - List running containers
-    - Add `-a` to see all containers
-  - `docker container start/stop NAME`
-    - Start/stop container
-  - `docker container attach NAME`
-    - Attach to running container
-  - `docker build`
-    - Creates an image from a given Dockerfile
-  - `docker cp`
-    - Copy files in/out of container
-  - `docker image history IMAGE`
-    - Show layers of image (including commands)Vagrant
-  - `docker system prune`
-    - Remove all unused objects (images, containers...)
-  - `docker logs ID/NAME`
-    - Shows log files of container
+    - `docker run OPTIONS`
+        - Run a container
+    - `docker image ls`
+        - List locally available images
+    - `docker pull NAME:TAG`
+        - Pulls an image from registry, `TAG` optional
+    - `docker container create IMAGE`
+        - Create container from image
+    - `docker container ls`
+        - List running containers
+        - Add `-a` to see all containers
+    - `docker container start/stop NAME`
+        - Start/stop container
+    - `docker container attach NAME`
+        - Attach to running container
+    - `docker build`
+        - Creates an image from a given Dockerfile
+    - `docker cp`
+        - Copy files in/out of container
+    - `docker image history IMAGE`
+        - Show layers of image (including commands)Vagrant
+    - `docker system prune`
+        - Remove all unused objects (images, containers...)
+    - `docker logs ID/NAME`
+        - Shows log files of container
 - Explain text-based format (infrastructure as code)
 - One can pre-build own images to reuse them later.
 - Has a layer based build process (which is nice). We do not have to rebuild from scratch, if build fails.
 - Images can be shared via DockerHub or other registries
 - Building an image can be pain in the neck as it depends on a fast internet connection.
 - Installation issue/security risks: Docker user group is basically root
-  - Rootless installation of Docker
-  - Namespaces
-  - Docker considers itself quite safe
+    - Rootless installation of Docker
+    - Namespaces
+    - Docker considers itself quite safe
 - We focus on tools to create, run and interact with containers
 
 Source: [https://docs.docker.com/get-started/overview/](https://docs.docker.com/get-started/overview/)
@@ -316,10 +316,10 @@ Source: [https://docs.docker.com/get-started/overview/](https://docs.docker.com/
 
 - Start VM with docker
 
-  ```
-  cd /media/jaustar/external-ssd/virtualmachines/vagrant/sse-docker-box/
-  vagrant up
-  ```
+    ```
+    cd /media/jaustar/external-ssd/virtualmachines/vagrant/sse-docker-box/
+    vagrant up
+    ```
 
 - Show containers on [DockerHub](https://hub.docker.com/)
 
@@ -333,18 +333,18 @@ Source: [https://docs.docker.com/get-started/overview/](https://docs.docker.com/
 #### Tutorial Case
 
 - From tutorial `docker run -i -t ubuntu /bin/bash`
-  - This pulls the latest `ubuntu` image `docker pull ubuntu`
-  - Creates container `docker container create`
-  - Creates read-write filesystem (last layer)
-  - Creates network interface
-  - Starts container and runs `/bin/bash`
-  - `-i` means interactive
-  - `-t` allocates pseudo-tty
+    - This pulls the latest `ubuntu` image `docker pull ubuntu`
+    - Creates container `docker container create`
+    - Creates read-write filesystem (last layer)
+    - Creates network interface
+    - Starts container and runs `/bin/bash`
+    - `-i` means interactive
+    - `-t` allocates pseudo-tty
 - Note that the container will still be there `docker container list -a` vs. `docker container list -a`
 - We can make sure that the container is removed after exiting by the `--rm` options, i.e., `docker run --rm -i -t ubuntu /bin/bash`
 
 - When container is running, we see it when calling `docker ps`
-- Start container (with name `tutoral`) `docker run --rm -i -t --name tutorial ubuntu  /bin/bash`
+- Start container (with name `tutoral`) `docker run --rm -i -t --name tutorial ubuntu    /bin/bash`
 - Leave it `CTRL-P` + `CTRL-Q` (do not let go of `CTRL` while doing this)
 - Show container running `docker ps`
 - Reattach to container `docker container attach tutorial`
@@ -353,55 +353,55 @@ Source: [https://docs.docker.com/get-started/overview/](https://docs.docker.com/
 #### Files in containers
 
 - We can change files inside the container.
-  - `docker run -i -t ubuntu /bin/bash`
-  - `touch asdf`
-  - leave container
-  - enter container `docker run -i -t ubuntu /bin/bash`
-  - File is not present because we implicitly created a new container based on the same image.
+    - `docker run -i -t ubuntu /bin/bash`
+    - `touch asdf`
+    - leave container
+    - enter container `docker run -i -t ubuntu /bin/bash`
+    - File is not present because we implicitly created a new container based on the same image.
 
 #### Detached Containers
 
 - `docker run -d -i -t --name test --mount type=bind,source="$(pwd)",target=/mnt/share ubuntu`
-  - Create detached container and bind mount
-  - Will run cotnainer in detached mode, names it `test` and mounts current directory on Host to `/mnt/share`. Is based on `ubuntu` image.
-  - Bind mount your source code for development for example
-  - I do not need `/bin/bash` because that is the default command for the `ubuntu` image.
+    - Create detached container and bind mount
+    - Will run cotnainer in detached mode, names it `test` and mounts current directory on Host to `/mnt/share`. Is based on `ubuntu` image.
+    - Bind mount your source code for development for example
+    - I do not need `/bin/bash` because that is the default command for the `ubuntu` image.
 
 #### Restarting a stopped container with arbitrary command
 
 - This is currently not possible. The default command or entrypoint is part of the runnable container. One has to create a new container from the stopped container to start it with another command
 - See also GitHub issues
-  - [docker exec into a stopped container](https://github.com/moby/moby/issues/18078). There is also a workaround mentioned in this issue
+    - [docker exec into a stopped container](https://github.com/moby/moby/issues/18078). There is also a workaround mentioned in this issue
 
-    ```basg
-    docker commit $STOPPED_CONTAINER user/test_image
-    docker run -ti --entrypoint=sh user/test_image
-    ```
+        ```basg
+        docker commit $STOPPED_CONTAINER user/test_image
+        docker run -ti --entrypoint=sh user/test_image
+        ```
 
-    Also interesting quote
+        Also interesting quote
 
-    > The main reason why is because containers are supposed to be immutable. You cannot exec into a stopped container because it has be be running first.
+        > The main reason why is because containers are supposed to be immutable. You cannot exec into a stopped container because it has be be running first.
 
-  - [`docker exec` in stopped containers](https://github.com/moby/moby/issues/30361)
+    - [`docker exec` in stopped containers](https://github.com/moby/moby/issues/30361)
 - See some workaround on [StackOverflow](https://stackoverflow.com/questions/32353055/how-to-start-a-stopped-docker-container-with-a-different-command)
-  - Find container id `docker container list -a`
-  - Commit stopped container to save its modifed state into a new image `docker commit CONTAINERID USER/IMAGENAME`
-  - Start new container with differnt entry point `docker run -ti --entrypoint=sh USER/IMAGENAME` if an entrypoint is specified in the previews image or `docker run -ti USER/IMAGENAME /bin/sh`
-  - For details on the difference between entry points (`ENTRYPOINT`) and the default for executing a container (`CMD`) check the [Dockerfile reference](https://docs.docker.com/engine/reference/builder/)
+    - Find container id `docker container list -a`
+    - Commit stopped container to save its modifed state into a new image `docker commit CONTAINERID USER/IMAGENAME`
+    - Start new container with differnt entry point `docker run -ti --entrypoint=sh USER/IMAGENAME` if an entrypoint is specified in the previews image or `docker run -ti USER/IMAGENAME /bin/sh`
+    - For details on the difference between entry points (`ENTRYPOINT`) and the default for executing a container (`CMD`) check the [Dockerfile reference](https://docs.docker.com/engine/reference/builder/)
 
 ### Demo: Building own example
 
 - `cd dockerfile-example`
 - Contains Dockerfile
 
-  ```Dockerfile
-  FROM ubuntu:18.04
+    ```Dockerfile
+    FROM ubuntu:18.04
 
-  RUN apt update -y && apt install -y neofetch
-  WORKDIR /app
-  COPY testfile .
-  CMD ["echo", "hello"]
-  ```
+    RUN apt update -y && apt install -y neofetch
+    WORKDIR /app
+    COPY testfile .
+    CMD ["echo", "hello"]
+    ```
 
 - `docker build --tag testimage .`
 - `docker run -i -t testimage /bin/bash`
@@ -419,8 +419,8 @@ Source: [https://docs.docker.com/get-started/overview/](https://docs.docker.com/
 ### Demo: DuMuX Dockerfile
 
 - Show more complicated Dockerfile example (`dumux-precice`)?
-  - `~/container-recipes/docker/dumux-precice/ub2004/dumux-3.4-precice-2.2.1`. Also in branch of [`dumux-precice` repository](https://git.iws.uni-stuttgart.de/dumux-appl/dumux-precice/-/blob/add-docker-images/docker/dumux-3.4-precice-2.2.1.dockerfile)+
-  - Uses most/all commands on slides
+    - `~/container-recipes/docker/dumux-precice/ub2004/dumux-3.4-precice-2.2.1`. Also in branch of [`dumux-precice` repository](https://git.iws.uni-stuttgart.de/dumux-appl/dumux-precice/-/blob/add-docker-images/docker/dumux-3.4-precice-2.2.1.dockerfile)+
+    - Uses most/all commands on slides
 
 ### Demo: FEniCS example
 
@@ -437,34 +437,34 @@ Source: [https://docs.docker.com/get-started/overview/](https://docs.docker.com/
 | 20 minutes | Slides + Demos|
 
 - Back story
-  - Created at Lawrence Berkeley National Laboratory but now developed by SyLabs
-  - Based on Go
+    - Created at Lawrence Berkeley National Laboratory but now developed by SyLabs
+    - Based on Go
 - Container solution with high-performance computing in mind
-  - "Mobility of compute", "Bring your own environment"
-    - Mobility of your compute environment
-    - Normally immutable images
-  - Integration in scheduling systems
-  - Runs in *user-space* (no root privilege escalation)
-  - Direct network and (some) hardware access (GPUs, accelerators)
-  - Mounts common/important directories
-  - Show text-based file format. Is similar to Docker
-    - Building is without layers (hit or miss)
-    - Images can be based on Docker images. This is nice to prebuild parts of the image as Docker image since Singularity's format is not layer based. This means you have to rebuilt from scratch if it fails.
-  - Small runtime penalty.
+    - "Mobility of compute", "Bring your own environment"
+        - Mobility of your compute environment
+        - Normally immutable images
+    - Integration in scheduling systems
+    - Runs in *user-space* (no root privilege escalation)
+    - Direct network and (some) hardware access (GPUs, accelerators)
+    - Mounts common/important directories
+    - Show text-based file format. Is similar to Docker
+        - Building is without layers (hit or miss)
+        - Images can be based on Docker images. This is nice to prebuild parts of the image as Docker image since Singularity's format is not layer based. This means you have to rebuilt from scratch if it fails.
+    - Small runtime penalty.
 - Nowadays available on many HPC platforms
 - Common commands
 
 ### Demo: Run prebuilt containers
 
 - `singularity pull library://lolcow`
-  - Obtain existing container image and store it as `lolcow_latest.sif`
+    - Obtain existing container image and store it as `lolcow_latest.sif`
 - `singularity pull lolcow_docker.sif docker://sylabsio/lolcow`
-  - Pulls docker image, converts it and stores it as lolcow_docker.sif
+    - Pulls docker image, converts it and stores it as lolcow_docker.sif
 - `singularity shell lolcow_latest.sif`
-  - Run shell in container
-  - `whoami` will show same user as I am on the computer
+    - Run shell in container
+    - `whoami` will show same user as I am on the computer
 - `singularity exec lolcow_latest.sif cowsay moo`
-  - Run command in container
+    - Run command in container
 - Show the mounted filesystems and hardware access.
 - Show that we cannot run things as root.
 - Note that images are executable by default
@@ -473,26 +473,26 @@ Source: [https://docs.docker.com/get-started/overview/](https://docs.docker.com/
 
 - Recipe `singularity-example.def`
 
-  ```Singularity
-  BootStrap: library
-  From: ubuntu:16.04
+    ```Singularity
+    BootStrap: library
+    From: ubuntu:16.04
 
-  %post
-      apt-get -y update
-      apt-get -y install fortune cowsay lolcat
+    %post
+            apt-get -y update
+            apt-get -y install fortune cowsay lolcat
 
-  %environment
-      export LC_ALL=C
-      export PATH=/usr/games:$PATH
+    %environment
+            export LC_ALL=C
+            export PATH=/usr/games:$PATH
 
-  %runscript
-      fortune | cowsay | lolcat
-  ```
+    %runscript
+            fortune | cowsay | lolcat
+    ```
 
 - Go to `/media/jaustar/external-ssd/singularity/singularity-examples/build-image`
 - Show file `singularity-example.def` content
 - `sudo singularity build testimage singularity-example.def`
-  - Point out that sudo is needed
+    - Point out that sudo is needed
 - Creates image which is identical to the prebuilt image
 
 ## Concluding Remarks and Discussion about Learning Goals
@@ -508,7 +508,7 @@ Source: [https://docs.docker.com/get-started/overview/](https://docs.docker.com/
 - Singularity is a bit more "niche", but important in the computing/simulation business as it focuses on self-contained applications that can easily run on different platforms instead of isolation compared to Docker.
 - For the exercise you should ideally have Docker, VirtualBox, Vagrant (maybe Singularity installed).
 - Show slides from the intro with learning goals again.
-  - Can you answer the questions now?
+    - Can you answer the questions now?
 
 ## Further Reading
 


### PR DESCRIPTION
This PR will fix problems with mixing ordered and unordered lists.

Mixing ordered and unordered lists creates a failing pipeline. A sublist of an ordered list needs at least three spaces for indentation

```
1. Item 1
   - Sub item
2. Item 2
```

Using three spaces however is inconsistent with some of our files where we used only two spaces of indentation which is fine if one only nests unordered lists. 

This PR closes #32 

## What does this PR do?

- Request an indentation of sublists by four  space characters. The minimum for rule MD005 and MD007 to work together is three spaces. However, a three space indentation is unusual and four spaces are already common for code blocks, for example. This is also mentioned in the [markdownlint documentation on rule MD007](https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md007---unordered-list-indentation)
- Reformat files to use 4 space indent for sublists.
- On the way I fixed a formatting issue in the README.md.
- On the way I fixed some formatting inconsistency in the header of slides.

## References

- [markdownlint documentation on rule MD007](https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md007---unordered-list-indentation)