### PR TITLE
Fix broken links

### DIFF
--- a/building-and-packaging/material/cmake_demo_notes.md
+++ b/building-and-packaging/material/cmake_demo_notes.md
@@ -1,6 +1,6 @@
 # Notes for CMake demo
 
-Example code is in [`building-and-packaging/material/examples/cmake`](https://github.com/Simulation-Software-Engineering/Lecture-Material/tree/main/building-and-packaging/examples/cmake). Example adapted from [Yanson Tech](https://www.youtube.com/watch?v=wl2Srog-j7I)
+Example code is in [`building-and-packaging/material/examples/cmake`](https://github.com/Simulation-Software-Engineering/Lecture-Material/tree/main/building-and-packaging/material/examples/cmake). Example adapted from [Yanson Tech](https://www.youtube.com/watch?v=wl2Srog-j7I)
 
 ## CMake "Hello World"
 

--- a/building-and-packaging/material/make_demo_notes.md
+++ b/building-and-packaging/material/make_demo_notes.md
@@ -1,6 +1,6 @@
 # Notes for Make demo
 
-Example code is in [`building-and-packaging/material/examples/make`](https://github.com/Simulation-Software-Engineering/Lecture-Material/tree/main/building-and-packaging/examples/make).
+Example code is in [`building-and-packaging/material/examples/make`](https://github.com/Simulation-Software-Engineering/Lecture-Material/tree/main/building-and-packaging/material/examples/make).
 
 ## "Hello World" starting point
 

--- a/building-and-packaging/overview.md
+++ b/building-and-packaging/overview.md
@@ -60,4 +60,4 @@ Learning goals:
 
 | Duration | Format | Material |
 | --- | --- | --- |
-| 45 minutes | slides and demo | [cmake_slides.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/building-and-packaging/material/make_slides.md), [cmake_demo_notes.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/building-and-packaging/material/make_demo_notes.md)
+| 45 minutes | slides and demo | [cmake_slides.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/building-and-packaging/material/cmake_slides.md), [cmake_demo_notes.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/building-and-packaging/material/cmake_demo_notes.md)


### PR DESCRIPTION
Fixed broken links for [cmake_slides.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/building-and-packaging/material/cmake_slides.md) and [cmake_demo_notes.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/building-and-packaging/material/cmake_demo_notes.md) by adding missing c