### PR TITLE
Add pull request template

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,13 @@
+## Description
+<!--- Please describe shortly what this pull request ist doing. If there is an related issue, please mention it here. -->
+
+## Checklist
+<!--- Please make sure to go over all points on the checklist and mark them as checked. -->
+- [ ] I made sure that the markdown files are formatted properly.
+- [ ] I made sure that all hyperlinks are working.
+
+If the pull request adds new content
+
+- [ ] I added the new content to the `README.md` inside the topics subdirectory, e.g., `01_version_control/README.md`.
+- [ ] I added the new content to the `timetabe.md` in the root of this repository.
+- [ ] I make sure to update the content/links on the [homepage](https://github.com/Simulation-Software-Engineering/homepage).

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,12 +1,15 @@
 ## Description
+
 <!--- Please describe shortly what this pull request ist doing. If there is an related issue, please mention it here. -->
 
 ## Checklist
+
 <!--- Please make sure to go over all points on the checklist and mark them as checked. -->
+
 - [ ] I made sure that the markdown files are formatted properly.
 - [ ] I made sure that all hyperlinks are working.
 
-If the pull request adds new content
+<!-- If the pull request adds new content, please check the points beloew. Otherwise remove the following lines. -->
 
 - [ ] I added the new content to the `README.md` inside the topics subdirectory, e.g., `01_version_control/README.md`.
 - [ ] I added the new content to the `timetabe.md` in the root of this repository.


### PR DESCRIPTION
In order to remember what files have to be updated when adding new contents a pull request template is added. The template contains a checklist of things to do before a PR is merged.

Some more information can be found in the [GitHub documentation on pull request templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates#pull-request-templates)

Do you think anything is missing here?