### PR TITLE
Bugfix: Install caption package in "PDF creation" action

### DIFF
--- a/.github/workflows/create-pdfs-from-markdown.yml
+++ b/.github/workflows/create-pdfs-from-markdown.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Install bash
         run: apk add bash
+      - name: Quick fix (pandoc), install Latex package caption
+        run: tlmgr install caption
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Compile PDFs (slides)


### PR DESCRIPTION
## Description

The latest pandoc image seems to be broken. To fix it we install the caption package in the GitHub action. Otherwise, the creation of the slides failes.

## Checklist

- [x] I made sure that the markdown files are formatted properly.
- [x] I made sure that all hyperlinks are working.
