### PR TITLE
Revert "Fix: Install caption package in GitHub Action (#81)"

### DIFF
--- a/.github/workflows/create-pdfs-from-markdown.yml
+++ b/.github/workflows/create-pdfs-from-markdown.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - name: Install bash
         run: apk add bash
-      - name: Quick fix (pandoc), install Latex package caption
-        run: tlmgr install caption
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Compile PDFs (slides)


### PR DESCRIPTION
## Description

This reverts commit 369310938681d8bf7bb29d956eee8d81466b684f.

The problem was due to some problem in the pandoc image which has been fixed (see https://github.com/pandoc/dockerfiles/issues/165). Therefore, we can revert the change in the configuration of the "PDF creation" Action.
