### PR TITLE
Extend pandoc demo and fix pandoc slides

### DIFF
--- a/04_documentation/README.md
+++ b/04_documentation/README.md
@@ -12,5 +12,6 @@ Learning Goals
 | --- | --- |
 | 90 minutes | [`technical_writing_slides.md`](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/04_documentation/technical_writing_slides.md) |
 | 20 minutes | [`markup_languages_slides.md`](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/04_documentation/markup_languages_slides.md), [`markup_languages_demo.md`](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/04_documentation/markup_languages_demo.md) |
+| 25 minutes | [`pandoc_slides.md`](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/04_documentation/pandoc_slides.md), [`pandoc_demo.md`](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/04_documentation/pandoc_demo.md) |
 | 70 minutes | [`tools_slides.md`](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/04_documentation/tools_slides.md), [`markup_languages_demo.md`](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/04_documentation/tools_demo.md) |
 | 60 minutes | [`tools_exercise.md`](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/04_documentation/tools_exercise.md) |

--- a/04_documentation/pandoc_demo.md
+++ b/04_documentation/pandoc_demo.md
@@ -1,16 +1,48 @@
 # Pandoc Demo
 
-- GitHub Action script
-    - Lecture slides
-    - Lecture notes
+- Show [Try Pandoc](https://pandoc.org/try/)
+    - **Note**: The list of options is not complete here!
+- Show very simple example on try pandoc
+
+  ```markdown
+  ---
+  title: My awesome title
+  author: Firstname lastname
+  date: 2022-01-27
+  ---
+
+  # Introduction
+
+  This is my text
+  ```
+
+  Convert to different file formats
+
+  If we have time also compile to PDF locally.
+
 - Convert exercise sheet with default template
 
   ```bash
   pandoc packaging_spack_exercise.md --pdf-engine=xelatex --listings -V colorlinks -o packaging_spack_exercise.pdf
   ```
 
-  with `eisvogel` template
+  with [`eisvogel` template](https://github.com/Wandmalfarbe/pandoc-latex-template)
 
   ```bash
   pandoc packaging_spack_exercise.md --pdf-engine=xelatex --template eisvogel --listings -V colorlinks -o packaging_spack_exercise.pdf
   ```
+
+- GitHub Action and script for lecture material.
+    - [Link to the actions](https://github.com/Simulation-Software-Engineering/Lecture-Material/tree/main/.github/workflows)
+    - [Link to the scripts](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/scripts/create-pdf-from-markdown.sh)
+    - Current lecture slides command:
+
+      ```text
+      pandoc --pdf-engine=xelatex -t beamer -V aspectratio=169 -V linkcolor:blue -V fontsize=12pt --listings -s --output=OUTPUTFILENAME INPUTFILENAME
+      ```
+
+    - Current lecture notes command:
+
+      ```text
+      pandoc --pdf-engine=xelatex -V geometry:a4paper -V geometry:left=2.5cm -V geometry:right=2.5cm -V geometry:bottom=2.5cm -V geometry:top=2.5cm -V colorlinks:true -V linkcolor:blue -V fontsize=10pt --listings -s --output=OUTPUTFILENAME INPUTFILENAME
+      ```

--- a/04_documentation/pandoc_slides.md
+++ b/04_documentation/pandoc_slides.md
@@ -38,6 +38,7 @@ slideOptions:
 
 ## Learning Goals
 
+- You know how to reuse your markup files for different purposes.
 - You know how to convert markup files (Markdown, reStructuredText...) written into other formats (Markdown, reStructuredText...)
 
 ---
@@ -79,7 +80,7 @@ According to the project [homepage](https://pandoc.org/)
   ```
 
     - Without `OPTIONS` default values are used
-    - Deduces conversion type from `OUTPUTFILE` file extension
+    - Deduces conversion type from `OUTPUTFILE` file extension (by default)
 - Extensive number of [options](https://pandoc.org/MANUAL.html#options)
 
 ---
@@ -89,7 +90,7 @@ According to the project [homepage](https://pandoc.org/)
 - From file format to file format
 
   ```bash
-  -f FORMAT -to FORMAT
+  --from/-f FORMAT --to/-t FORMAT
   ```
 
 - Create [standalone](https://pandoc.org/MANUAL.html#option--standalone) file
@@ -162,9 +163,13 @@ According to the project [homepage](https://pandoc.org/)
   title: "My awesome title"
   author: Alexander Jaust
   ...
+  ---
   ```
 
   May also be specified in separate `yaml` file.
+
+- Available parameters depend on template
+- Parameter missing? -> Build own template
 
 ---
 

--- a/timetable.md
+++ b/timetable.md
@@ -129,7 +129,7 @@
 
 ## 12.1 -- Thu, January 27, 2022
 
-- **45** Document conversion with Pandoc : [slides](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/04_documentation/pandoc_slides.md), [demo](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/04_documentation/pandoc_demo.md)
+- **25** Document conversion with Pandoc : [slides](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/04_documentation/pandoc_slides.md), [demo](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/04_documentation/pandoc_demo.md)
 
 ## 12.2 -- Thu, January 27. 2022
 


### PR DESCRIPTION
## Description

This PR extends the pandoc demo by an additional example and adds links to examples and templates. The PR also fixes some small mistakes in the pandoc slides.

## Checklist

- [x] I made sure that the markdown files are formatted properly.
- [x] I made sure that all hyperlinks are working.
- [x] I added the new content to the `README.md` inside the topics subdirectory, e.g., `01_version_control/README.md`. -> I do not know yet where to put it in.
- [x] I added the new content to the `timetable.md` in the root of this repository.
- [x] I make sure to update the content/links on the [homepage](https://github.com/Simulation-Software-Engineering/homepage).
