### PR TITLE
Modify PyPI exercise to use `setup.cfg` and `pyproject.toml`

### DIFF
--- a/03_building_and_packaging/pypi_exercise.md
+++ b/03_building_and_packaging/pypi_exercise.md
@@ -28,7 +28,7 @@ In this exercise you will convert a raw Python code into a packaged code which i
 - Open the file `diffusion2d.py` and go through the file and try to understand the code components.
 - Install `python >= 3.6`.
 - Install pip, build, and Twine.
-- Install NumPy and Matplotlib with `pip`. The installation instructions can be found on the webpages (link in the Prerequisities section of this document).
+- Install NumPy and Matplotlib with `pip`. The installation instructions can be found on the webpages (link in the Prerequisites section of this document).
 - Run the code using `python3 diffusion2d.py` and observe the output. You should see four plots combined into one figure. Save this figure on your system.
 - **Information about diffusion2d.py**: This code solves the diffusion equation in 2D over a square domain which is at a certain temperature and a circular disc at the center which is at a higher temperature. This code solves the diffusion equation using the Finite Difference Method. The thermal diffusivity and initial conditions of the system can be changed by the user. The code produces four plots at various timepoints of the simulation. The diffusion process can be clearly observed in these plots.
 - Take a few minutes to play around with parameters `dx`, `dy` and `D` in the solver file and observe how the value of `dt` and the output changes. Do you notice if the code takes more or less time to finish the computation? *This tuning is only for you to understand the underlying physical phenomenon and not part of the evaluation.*
@@ -36,20 +36,20 @@ In this exercise you will convert a raw Python code into a packaged code which i
 
 ## Step 2 - Refactoring the code
 
-- It is usually a good idea to put different functionality in different files for better organization and code sustanability. We will do the same here.
+- It is usually a good idea to put different functionality in different files for better organization and code sustainability. We will do the same here.
 - Create a file `output.py` on the same level as `diffusion2d.py`.
 - Create two functions in the file `output.py` called `create_plot()` and `output_plots()`.
     - The function `create_plot()` creates one plot for a particular time stamp. In the earlier figure output this would be one of the four plots. You will find this functionality inside the time loop in `diffusion2d.py`
     - The function `output_plots()` outputs all the four plots as one figure. You will find this functionality outside of the time loop and at the end of `diffusion2d.py`
 - Port the appropriate parts of the code pertaining to figure creation and figure output from `diffusion2d.py` into these two functions.
 - Take care to pass the appropriate arguments to both these functions. Code refactoring should not affect the functionality, that is, the refactored code should work exactly as the original `diffusion2d.py`.
-- Once the functionality is ported, you need to import it into the `diffusion2d.py`. This is done in the following way:
+- Once the functionality is ported, you need to import it into the `diffusion2d.py`. This is done in the following way
 
 ```python
 from .output import create_plot, output_plots
 ```
 
-- Once the output functionality has been separated from the solver, we need to bundle the solver itself into a function called `solve` in `diffusion2d.py`. We need to do this because later on we will call this function after importing the package:
+- Once the output functionality has been separated from the solver, we need to bundle the solver itself into a function called `solve` in `diffusion2d.py`. We need to do this because later on we will call this function after importing the package
 
 ```python
 from package_name import diffusion2d
@@ -57,16 +57,20 @@ from package_name import diffusion2d
 diffusion2d.solve()
 ```
 
-- Once you have refactored the code, try calling the `solve()` function again through a Python script as shown above or a Python shell. Compare the plots with the plots in the figure you saved earlier. Both outputs should be identical.
+- Once you have refactored the code, try calling the `solve()` function again through a Python script or directly in a Python shell. Compare the plots with the plots in the figure you saved earlier. Both outputs should be identical.
 - The function `solve()` should take in physical parameters which the user can vary. In this case change the parameters `dx`, `dy` and `D` such that they are passed to the `solve()` function by the user. Provide default values for all three of these parameters.
 
 ## Step 3 - Creating folder structure for packaging
 
 - Now that you have a refactored code, replicate the folder structure we learnt in the lecture to prepare the code for packaging
-- With the help of the [lecture notes](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/pypi_slides.md) create additional files `setup.py`, `__init__.py`, `README.md` and the `src/` director
-- The `README.md` file consists of a longer description about the code and what it does. Take the information about the code from Step 1 of this exercise and add it to the README. In addition to this fill out the emtpy sections of the README with relevant information.
-- In `setup.py` name your package `<your-GitLab-username>diffusion2D`. We will use semantic versioning, so the version you are developing will be `0.0.1`. The package url is the url of the GitHub repository of this exercise code.
-- Try to put `classifiers` in your `setup()`.
+- With the help of the [lecture notes](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/pypi_slides.md) create additional files `setup.py`, `setup.cfg`, `pyproject.toml`, `__init__.py` and `README.md`.
+- It is not mandatory to have the `src/` folder, but some developers prefer the name to clearly indicate which part of the repository has the *source* files.
+- **Note**: General recommendation is to have the name of the folder having the source files to be same as the name of the package as seen when imported at the time of use.
+- The `README.md` file consists of a longer description about the code and what it does. Take the information about the code from Step 1 of this exercise and add it to the README. In addition to this fill out the empty sections of the README with relevant information.
+- In the configuration (either `setup.cfg` or `pyproject.toml`) name your package `<your-GitLab-username>diffusion2D`. We will use semantic versioning, so the version you are developing will be `0.0.1`. The package url is the url of the GitHub repository of this exercise code.
+- Make a choice of using either `setup.cfg` or `pyproject.toml` to configure `setuptools` for the packaging. All configuration options needs to be specified in the configuration file and the setup file should only consist of the call to `setuptools.setup()`.
+- As the package should be easy to install and provide maximum possible information, try to include as many configuration options as possible.
+- Hint: Have a look at the guides on [configuring setuptools with setup.cfg](https://setuptools.pypa.io/en/latest/userguide/declarative_config.html) and [configuring setuptools with pyproject.toml](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html). All the options covered in the lecture notes are applicable for this exercise.
 
 ## Step 4 - Create distribution archives
 

--- a/03_building_and_packaging/pypi_slides.md
+++ b/03_building_and_packaging/pypi_slides.md
@@ -95,6 +95,9 @@ setup(
     packages=setuptools.find_packages(where="<directory-name>"),
     python_requires=">=3.6",
     install_requires=["<dependencies>"]
+    entry_points={
+      'console_scripts': ['package-import-name = <path-to-main-function-with-dots>']
+    }
 )
 ```
 
@@ -112,11 +115,23 @@ author="Your Name"
 url="package-website-url"
 
 [options]
+packages = find:
 install_requires =
   "<dependencies>"
+
+[options.entry_points]
+console_scripts = 
+  executable-name = <path-to-main-function-with-dots>
 ```
 
-Additionally `setup.cfg` can have flags for packages, for example `[bdist_wheel]`.
+A nominal `setup.py` is still required
+
+```python
+from setuptools import setup
+
+if __name__ == "__main__":
+  setup()
+```
 
 ---
 

--- a/03_building_and_packaging/pypi_slides.md
+++ b/03_building_and_packaging/pypi_slides.md
@@ -113,14 +113,16 @@ name="package-name"
 version="<version-number>"
 author="Your Name"
 url="package-website-url"
+description="A small description"
 
 [options]
 packages = find:
 install_requires =
   "<dependencies>"
+  python_version>"3.6"
 
 [options.entry_points]
-console_scripts = 
+console_scripts =
   executable-name = <path-to-main-function-with-dots>
 ```
 
@@ -146,7 +148,25 @@ Example `pyproject.toml` can look like
 ```python
 [build-system]
 requires = ["setuptools", "wheel"]
+
+[project]
+name = "package-name"
+description = "A small description"
+readme = "README.md"
+requires-python = ">=3.6"
+keywords = ["keyword1", "keyword2"]
+license = {text = "BSD License"}
+classifiers = [
+    "Programming Language :: Python :: 3"
+]
+dependencies = [
+    "requests",
+    'importlib-metadata; python_version<"3.8"',
+]
+dynamic = ["<version-number>"]
 ```
+
+A nominal `setup.py` is still required.
 
 ---
 


### PR DESCRIPTION
## Description

This PR modifies the exercise of packaging a Python code to use `setup.cfg` and `pyproject.toml` to configure `setuptools` during packaging.

## Checklist

<!--- Please make sure to go over all points on the checklist and mark them as checked. -->

- [x] I made sure that the markdown files are formatted properly.
- [x] I made sure that all hyperlinks are working.

<!-- If the pull request adds new content, please check the points below. Otherwise remove the following lines. -->

- [ ] I added the new content to the `README.md` inside the topics subdirectory, e.g., `01_version_control/README.md`.
- [ ] I added the new content to the `timetable.md` in the root of this repository.
- [ ] I make sure to update the content/links on the [homepage](https://github.com/Simulation-Software-Engineering/homepage).
