### PR TITLE
feat(markdownlint): Add markdownlint configuration also as json

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,16 @@
+{
+    "default": true,
+    "MD002": false,
+    "MD004": { "style": "dash" },
+    "MD007": { "indent": 4 },
+    "MD010": false,
+    "MD012": false,
+    "MD013": { "line_length": 99999},
+    "MD026": {"punctuation": ".,;:!"},
+    "MD029": {"style":"ordered"},
+    "MD033": false,
+    "MD034": false,
+    "MD040": false,
+    "MD041": false,
+    "no-hard-tabs": false
+}

--- a/.mdl.rb
+++ b/.mdl.rb
@@ -1,3 +1,5 @@
+# Don't forget to also edit .markdownlint.json
+
 # Enable all rules by default
 all
 


### PR DESCRIPTION
## Description

Add the markdownlint configuration (currently in `.mdl.rb` also as json (`.markdownlint.json`)

This allows the javascript implementation of mdl to read them. See https://github.com/DavidAnson/markdownlint

That implementation is the only one supported by vscode (through https://github.com/DavidAnson/vscode-markdownlint)


## Checklist

<!--- Please make sure to go over all points on the checklist and mark them as checked. -->

- [x] I made sure that the markdown files are formatted properly.
- [x] I made sure that all hyperlinks are working.