### PR TITLE
improve(organization/course_intro): Add link to stuvus hedgedoc

### DIFF
--- a/00_organization/course_intro_slides.md
+++ b/00_organization/course_intro_slides.md
@@ -101,7 +101,7 @@ Two parallel branches:
 
 - Great new open-source book to recap: Irving, Hertweck, Johnston, Ostblom, Wickham, and Wilson: [Research Software Engineering with Python](https://merely-useful.tech/py-rse)
 - All our material is on [https://github.com/Simulation-Software-Engineering](https://github.com/Simulation-Software-Engineering)
-- Mainly markdown ... use your favorite tool to render (simply GitHub viewer, [GWDG Hedgedoc](https://pad.gwdg.de/), [pandoc](https://pandoc.org/), [PDFs generated in CI](https://github.com/Simulation-Software-Engineering/Lecture-Material/actions/workflows/create-pdfs-from-markdown.yml), ...)
+- Mainly markdown ... use your favorite tool to render (simply GitHub viewer, [GWDG Hedgedoc](https://pad.gwdg.de/), [stuvus Hedgedoc](https://pad.stuvus.de/), [pandoc](https://pandoc.org/), [PDFs generated in CI](https://github.com/Simulation-Software-Engineering/Lecture-Material/actions/workflows/create-pdfs-from-markdown.yml), ...)
 - We rework the material as the semester goes
 - We give many links to videos, docs, blog posts, podcasts, ...
 - Recordings of the lecture from last year as a backup on ILIAS. Please always come when possible. What we do is interactive.


### PR DESCRIPTION
## Description

Add link to stuvus hedgedoc to course intro slides.
As gwdg hedgedoc cannot be accessed with studi account anymore.

## Checklist

<!--- Please make sure to go over all points on the checklist and mark them as checked. -->

- [x] I made sure that the markdown files are formatted properly.
- [x] I made sure that all hyperlinks are working.
