### PR TITLE
Fix broken link

### DIFF
--- a/03_building_and_packaging/README.md
+++ b/03_building_and_packaging/README.md
@@ -17,7 +17,7 @@ Learning goals:
 | 50 minutes | [cpack_slides.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/cpack_slides.md), [cpack_demo.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/cpack_demo.md) |
 | 15 minutes | [intro_slides.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/intro_slides.md) |
 | 15 minutes | [make_slides.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/make_slides.md), [make_demo.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/make_demo.md) |
-| 30 minutes | [pip_demo.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/pypi_slides.md) |
+| 30 minutes | [pip_demo.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/pip_demo.md) |
 | 90 minutes | [pypi_exercise.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/pypi_exercise.md) |
 | 45 minutes | [pypi_slides.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/pypi_slides.md) |
 | 45 minutes | [spack_slides.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/spack_slides.md), [spack_demo.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/spack_demo.md) |


### PR DESCRIPTION
## Description

Link to pip_demo referred to wrong slides (pypi_slides).
The reference was fixed.

## Checklist

- [x] I made sure that the markdown files are formatted properly.
- [x] I made sure that all hyperlinks are working.
