### PR TITLE
Add link to fzf project

### DIFF
--- a/01_version_control/my_favorite_neat_little_git_trick_demo.md
+++ b/01_version_control/my_favorite_neat_little_git_trick_demo.md
@@ -59,6 +59,7 @@ What does it do?
 - Git Alias `fixup = "!git log -n 50 --pretty=format:'%h %s' --no-merges | fzf | cut -c -7 | xargs -o git commit --fixup"`
     - Allows committing current staged changes as a fixup commit for a previous commit
     - Follow by `git rebase -i --autosquash` (or enable `autosquash` for rebase on default in git config)
+    - Requires [`fzf`](https://github.com/junegunn/fzf) to be installed.
 - Automatically fix http(s) urls (changing it to the correct ssh url) using git config `url` section
     - Also allows copying url from browser
     - Also allows entering `gh://username/repo` by memory


### PR DESCRIPTION
## Description

I went through the latest Git tricks and found the `fixup` alias to look nicely. I added a short note that one needs [`fzf`](https://github.com/junegunn/fzf) for the alias as this is, to my knowledge, no standard Linux/Unix command. All other commands (`cut`, `xargs`) besides `git` look like they should be included in Linux/Unix by default.

## Checklist

- [x] I made sure that the markdown files are formatted properly.
- [x] I made sure that all hyperlinks are working.
