### PR TITLE
Update cpack lecture

### DIFF
--- a/03_building_and_packaging/README.md
+++ b/03_building_and_packaging/README.md
@@ -11,15 +11,16 @@ Learning goals:
 
 | Duration | Content |
 | --- | --- |
-| 45 minutes | [cmake_slides.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/cmake_slides.md), [cmake_demo.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/cmake_demo.md) |
+| 60 minutes | [cmake_slides.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/cmake_slides.md), [cmake_demo.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/cmake_demo.md) |
 | 90 minutes | [cmake_exercise.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/cmake_exercise.md) |
-| 60 minutes | [cpack_exercise.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/cpack_exercise.md) |
-| 50 minutes | [cpack_slides.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/cpack_slides.md), [cpack_demo.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/cpack_demo.md) |
+| 20 minutes | [cmake_more_demo.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/cmake_more_demo.md) |
+| 90 minutes | [cpack_exercise.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/cpack_exercise.md) |
+| 70 minutes | [cpack_slides.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/cpack_slides.md), [cpack_demo.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/cpack_demo.md) |
 | 15 minutes | [intro_slides.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/intro_slides.md) |
+| 25 minutes | [linux_fundamentals_slides.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/linux_fundamentals_slides.md), [linux_fundamentals_demo.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/linux_fundamentals_demo.md) |
 | 15 minutes | [make_slides.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/make_slides.md), [make_demo.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/make_demo.md) |
 | 30 minutes | [pip_demo.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/pip_demo.md) |
 | 90 minutes | [pypi_exercise.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/pypi_exercise.md) |
 | 45 minutes | [pypi_slides.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/pypi_slides.md) |
 | 45 minutes | [spack_slides.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/spack_slides.md), [spack_demo.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/spack_demo.md) |
 | 45 minutes | [spack_exercise.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/spack_exercise.md) |
-| 25 minutes | [linux_fundamentals_slides.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/linux_fundamentals_slides.md), [linux_fundamentals_demo.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/linux_fundamentals_demo.md) |

--- a/03_building_and_packaging/cmake_more_demo.md
+++ b/03_building_and_packaging/cmake_more_demo.md
@@ -1,0 +1,28 @@
+# Notes for More CMake Demo
+
+## Walk Through preCICE `CMakeLists.txt`
+
+- [`CMakeLists.txt` on GitHub](https://github.com/precice/precice/blob/develop/CMakeLists.txt)
+- First look around:
+    - `CMakeLists.txt`: lengthy
+    - `tree cmake`
+    - If software should be usable (for everybody everywhere), building and packaging is a project by itself
+- In `modules`: some `FindX.cmake`, partially third-party, partially developed by preCICE devs
+- In `CMakeLists.txt`: `sources.cmake` included (around line 345)
+    - No glob, but generated externally (some python script)
+    - Look at `src/sources.cmake`
+- Look at `CPackConfig.cmake`
+- `cmake ..` and read through output
+
+## CMake Curses Interface
+
+- There are many tools around CMake, `ccmake` is also developed by KitWare
+- Separate package on Ubuntu: `sudo apt-get install cmake-curses-gui`
+- Delete previous build folder and start from scratch
+- `ccmake ..`
+- `[c]` if not yet configured before
+- Change variable with `[enter]`, e.g. `CMAKE_BUILD_TYPE`
+- Look at short description of options at the bottom
+- `[t]` to show also CMake options, helpful to find out which variables exist
+- `[c]` to configure again (because we changed something)
+- `[g]` to generate `Makefile` and exit

--- a/03_building_and_packaging/cpack_demo.md
+++ b/03_building_and_packaging/cpack_demo.md
@@ -3,6 +3,7 @@
 Example code is in [`03_building_and_packaging/examples/cpack`](https://github.com/Simulation-Software-Engineering/Lecture-Material/tree/main/03_building_and_packaging/examples/cpack).
 
 - Show `main.cpp`, `sse/*`: same example as last week
+- Goal of this lecture: How can we give this software to somebody else in a proper way? Remember lecture on packaging for Python; now C++ code
 - Build and start Docker container:
     - `docker build -t "cpack_demo"`
     - `docker run -it cpack_demo`

--- a/03_building_and_packaging/cpack_demo.md
+++ b/03_building_and_packaging/cpack_demo.md
@@ -16,11 +16,15 @@ Example code is in [`03_building_and_packaging/examples/cpack`](https://github.c
     - We do this **for demonstration only**. There is normally no need handle internal dependencies in such a complicated way.
     - Build the code: We still get an executable `helloworld` and a library `libsse.a`.
 - Changes compared to previous version / last week:
-    - Version number, not needed yet, but good practice
+    - Version number, not needed yet (but later), but good practice
     - `set_target_properties`: Mark include files needed for `libsse` library (`sse/sse.hpp`) as publicly visible.
         - Needed such that CMake knows which headers should be public and should be installed. By default CMake assumes headers are for internal use (within the current project) only.
-    - `target_include_directories`: Where do we have to look for the dependency depending on the type of build (internally, top-level cmake project, external dependency) TODO
-    - Include CMake macro `GNUInstallDirs` to get predefined variables such as installation directories. Directories names and their purpose are defined in the [GNU coding standard](https://www.gnu.org/prep/standards/html_node/Directory-Variables.html). TODO
+    - `target_include_directories`: Where do we have to look for the dependency depending on the type of build (internally, top-level cmake project, external dependency).
+        - If there was a `src` directory, for example, mention it here (or `sse` and then don't mention above and in `main.cpp`).
+        - Classic strategy for headers to put them again in a folder named after the project (such that they don't get mixed up).
+        - We do not use the last two here, but they would be used if we created a package config file.
+        - `$<...>` notation: generator expressions, variables are evaluated during build system generation
+    - Include CMake macro `GNUInstallDirs` to get predefined variables such as installation directories. Directories names and their purpose are defined in the [GNU coding standard](https://www.gnu.org/prep/standards/html_node/Directory-Variables.html).
     - Create install targets (where to install to)
 - Build the library and install it (when installing or distributing a package always set a `CMAKE_BUILD_TYPE`)
 
@@ -111,7 +115,6 @@ Example code is in [`03_building_and_packaging/examples/cpack`](https://github.c
 - Many errors and warning, some easy to fix:
 
   ```diff
-  + set(CPACK_PACKAGE_CONTACT "SSE lecturers <firstname.lastname@example.com>")
   # strip really all Debug symbols
   + set(CPACK_STRIP_FILES TRUE)
   ```

--- a/03_building_and_packaging/cpack_demo.md
+++ b/03_building_and_packaging/cpack_demo.md
@@ -105,6 +105,7 @@ Example code is in [`03_building_and_packaging/examples/cpack`](https://github.c
   tree helloworld-unpacked
   ```
 
+- Look at `DEBIAN/control` file: dependencies, meta data
 - Check package via `lintian`: `lintian helloworld_0.1.0_amd64.deb`
 - Many errors and warning, some easy to fix:
 

--- a/03_building_and_packaging/cpack_demo.md
+++ b/03_building_and_packaging/cpack_demo.md
@@ -13,7 +13,7 @@ Example code is in [`03_building_and_packaging/examples/cpack`](https://github.c
 - Show `CMakeLists.txt`
 - First observations:
     - We still build a library (`add_library`) and then an executable (`add_executable`).
-    - We do this **for demonstration only**. There is normally no need handle internal dependencies that complicated.
+    - We do this **for demonstration only**. There is normally no need handle internal dependencies in such a complicated way.
     - Build the code: We still get an executable `helloworld` and a library `libsse.a`.
 - Changes compared to previous version / last week:
     - Version number, not needed yet, but good practice

--- a/03_building_and_packaging/cpack_demo.md
+++ b/03_building_and_packaging/cpack_demo.md
@@ -1,63 +1,27 @@
-# Debian packages
+# Notes for Installation and Packaging with CMake and CPack Demo
 
-## Learning goals
+Example code is in [`03_building_and_packaging/examples/cpack`](https://github.com/Simulation-Software-Engineering/Lecture-Material/tree/main/03_building_and_packaging/examples/cpack).
 
-- How to add an install target to a CMake project.
-- How to package a CMake project via `CPack`.
-- How to create a Debian (`deb`) package of your program/library using CPack.
-- How to check the resulting Debian package.
+- Show `main.cpp`, `sse/*`: same example as last week
+- Build and start Docker container:
+    - `docker build -t "cpack_demo"`
+    - `docker run -it cpack_demo`
 
-## 1. Preparing Project (Demo 1)
+## Add Install Target to CMake Configuration
 
-- We will extend the code from the previous lecture.
-    - [GitHub repository](https://github.com/Simulation-Software-Engineering/HelloWorld)
-- Make sure two files are created (a library and an executable). This should be the case when starting with the code from last week's lecture.
-    - **Warning** We handle example as an seperate executable + library **for demonstration** only. There is normally no need handle internal dependencies that complicated.
-- We add the following changes
-    - Adding a version number to the project. This is not needed yet, but I am afraid of forgetting it later.
-    - We mark the include files needed to use the `libsse` library, i.e., `sse/sse.hpp` as publicly visible. This is needed such that CMake knows which headers should be public and should be installed. By default CMake assumes headers are for interal use (within the current project) only.
-        - The [documentation](https://cmake.org/cmake/help/latest/prop_tgt/PUBLIC_HEADER.html) is a bit confusing as it hints that this should/could only be used with Apple framework projects.
-    - We define the target's include directory, i.e., where do we have to look for the dependency depending on the type of build (internally, top-level cmake project, external dependency)
-    - We want to make sure that we have an `install` target for make that, at the same time, considers typical installation directories. That means `make install` should binaries in a `<prefix>/bin`, libraries in `<prefix>/lib` or `<prefix>/lib/helloworld`, include files in `<prefix>/include` etc. We include the predefined CMake macro `GNUInstallDirs` to get predefined variables such as installation directories. The directories names and their purpose are defined in the [GNU coding standard](https://www.gnu.org/prep/standards/html_node/Directory-Variables.html).
-
-Changes:
-
-```diff
-- project("HelloWorld")
-+ project("HelloWorld" VERSION 0.1.0)
-+ add_library(sse sse/sse.cpp)
-+
-+ set_target_properties(sse PROPERTIES PUBLIC_HEADER sse/sse.hpp)
-
-+target_include_directories(sse
-+    PRIVATE
-+        # where the library itself will look for its internal headers
-+        ${CMAKE_CURRENT_SOURCE_DIR}/helloworld
-+    PUBLIC
-+        # where top-level project will look for the library's public headers
-+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/helloworld>
-+        # where external projects will look for the library's public headers
-+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/helloworld>
-+)
-
-+# Create install targets
-+include(GNUInstallDirs)
-+install(TARGETS helloworld sse
-+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/helloworld
-+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/helloworld
-+  )
-```
-
-- Fire up a prepared container for testing. Container is beneficial as it allows us to mess around with the container's paths without messing up our own system. From the example repository I run
-
-  ```bash
-  sudo docker run --rm -it --name ubuntu-packaging --mount type=bind,source="$(pwd)",target=/mnt/cpack-example jaustar/debian-package-building-base
-  ```
-
-- Build the library and install it
+- Show `CMakeLists.txt`
+- First observations:
+    - We still build a library (`add_library`) and then an executable (`add_executable`).
+    - We do this **for demonstration only**. There is normally no need handle internal dependencies that complicated.
+    - Build the code: We still get an executable `helloworld` and a library `libsse.a`.
+- Changes compared to previous version / last week:
+    - Version number, not needed yet, but good practice
+    - `set_target_properties`: Mark include files needed for `libsse` library (`sse/sse.hpp`) as publicly visible.
+        - Needed such that CMake knows which headers should be public and should be installed. By default CMake assumes headers are for internal use (within the current project) only.
+    - `target_include_directories`: Where do we have to look for the dependency depending on the type of build (internally, top-level cmake project, external dependency) TODO
+    - Include CMake macro `GNUInstallDirs` to get predefined variables such as installation directories. Directories names and their purpose are defined in the [GNU coding standard](https://www.gnu.org/prep/standards/html_node/Directory-Variables.html). TODO
+    - Create install targets (where to install to)
+- Build the library and install it (when installing or distributing a package always set a `CMAKE_BUILD_TYPE`)
 
   ```bash
   mkdir build && cd build
@@ -75,201 +39,80 @@ Changes:
   -- Installing: /usr/local/include/helloworld/sse.hpp
   ```
 
-  **Note** that we have an empty configuration here if we do not specify a `CMAKE_BUILD_TYPE`. Especially when distributing a package one should set a `CMAKE_BUILD_TYPE`.
-- Now we can run `helloworld` from anywhere on the system.
-    - We might need to set `PATH="/usr/local/bin":"${PATH}"`. In my container it was not set.
-- Tear down container
+- Run it: `helloworld`
+- `which helloworld`
+- Set the prefix: `cmake -DCMAKE_INSTALL_PREFIX="../installation" -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release ..`, install again, `tree` the folder.
 
-**Note**: At this point we have a package with reasonable installation routine. This is something we would need for (different) packaging solutions such as Debian packages and
+## Add CPack Configuration
 
-## 2. Extend CMake configuration (Demo 1)
-
-In this step we add a CPack configuration such that we can actually create a package.
-
-- We will add the configuration in another directory. Create `cmake/Packaging.cmake`
-    - This allows to separate different parts of the CMake configuration.
-- Additions to `CMakeLists.txt`
+- Packaging happens in separate CMake module called `CPackConfig.cmake`. Include it in `CMakeLists.txt`:
 
   ```diff
-  + # Packaging section
-  + # Adding other cmake modules
+  + # Adding other cmake modules (standard like this)
   + set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-  + # Include our packaging module
-  + include(Packaging)
+  + # Include our packaging module (standard like this)
+  + include(CPackConfig)
   ```
 
-- Edit `cmake/Packaging.cmake` and add some properties.
+- Look at `cmake/CPackConfig.cmake`:
+    - Basically only definition of meta information
     - `CPack` should be included at the end so it can ingest all preset variables
-    - We can set version, e.g., but by default it will ingest the version number from the `project()` statement in `CMakeLists.txt`.
-    - Full list of statements in [documentation](https://cmake.org/cmake/help/latest/module/CPack.html). Note, that the current statements are common properties of the packaging module.
+- `cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release ..`
+    - Creates new files `CPackConfig.cmake` and `CPackSourceConfig.cmake`
+    - Look at `CPackConfig.cmake`: things we added and much more (same name, same content)
+- Create package, e.g., `tar.gz`: `cpack -G TGZ`
+    - If this fails, this is due missing a `README.md` and `LICENSE` file. CPack expects these file to be present.
+    - `-G` is used to specify the package generator. We choose `TGZ` the generator for a compressed archive.
+    - We obtain the resulting file `HelloWorld-0.1.0-Linux.tar.gz`. The file name consists of the project name, version number and installation target.
+- Inspect the package: `tar -xzf HelloWorld-0.1.0-Linux.tar.gz` and `tree`
+- `make clean`
+- Build Debian package: `cpack -G DEB` ... builds again (no need to run `make` first) and complains: no dependencies set
+- `make clean` and `make package`: many things get created. Set default:
 
   ```diff
-  + set(CPACK_PACKAGE_NAME ${PROJECT_NAME})
-  +
-  + set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "SSE hello world example project"
-  +   CACHE STRING "Extended summary.")
-  +
-  + set(CPACK_PACKAGE_VENDOR "SSE Lecturers / Employer")
-  +
-  + set(CPACK_PACKAGE_CONTACT "firstname.lastname@example.com")
-  +
-  + set(CPACK_PACKAGE_HOMEPAGE_URL "https://simulation-software-engineering.github.io/homepage/")
-  +
-  + set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-  + set(CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-  + set(CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-  +
-  + include(CPack)
+  + set(CPACK_GENERATOR "TGZ;DEB")
   ```
 
-- Start up container again and then prepare project
+- `make clean` and `make package` again
 
-  ```bash
-  mkdir build && cd build
-  cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release ..
-  ```
+## Create Debian Package
 
-- This will create new files `CPackConfig.cmake` and `CPackSourceConfig.cmake`
-- We can create a package, e.g., `tar.gz`
-
-  ```bash
-  cpack -G TGZ
-  ```
-
-  **NOTE** If this fails, this is due missing a `README.md` and `LICENSE` file. CPack expects these file to be present. They are important! Especially the license.
-
-  `-G` is used to specify the package generator. We choose `TGZ` the generator for a compressed archive. We obtain the resulting file `HelloWorld-0.1.0-Linux.tar.gz`. The file name consists of the project name, version number and installation target.
-
-- Inspect the package
-
-  ```bash
-  tar -xzf HelloWorld-0.1.0-Linux.tar.gz
-  ```
-
-  The unpacked package in directory `HelloWorld-0.1.0-Linux` has three subdirectories `bin/`, `lib/`, `include/`.
-
-- We can also run `cpack -G DEB`, but it will complain
-
-  ```bash
-  $ cpack -G DEB
-  CPack: Create package using DEB
-  CPack: Install projects
-  CPack: - Run preinstall target for: HelloWorld
-  CPack: - Install project: HelloWorld []
-  CPack: Create package
-  -- CPACK_DEBIAN_PACKAGE_DEPENDS not set, the package will have no dependencies.
-  CPack: - package: /mnt/cpack-example/build/HelloWorld-0.1.0-Linux.deb generated.
-  ```
-
-  The dependencies are missing for example.
-
-## 3. Extend CPack configuration for Debian Package (Demo 2)
-
-- Setting up Debian package generator by adding lines to `cmake/Packaging.cmake`:
+- Set up Debian package generator by adding lines to `cmake/Packaging.cmake`:
 
   ```diff
   + # Debian packaging section
   + set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
   + set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS YES)
+  include(CPack)
   ```
 
-  `CPACK_DEBIAN_FILE_NAME` will set the package name to follow the standard package naming scheme (see slides) and `CPACK_DEBIAN_PACKAGE_SHLIBDEPS` set to `YES` will (try to) extract the dependencies automatically. We can also set dependencies manually (`CPACK_DEBIAN_PACKAGE_DEPENDS`).
+- `CPACK_DEBIAN_FILE_NAME` sets the package name to follow the standard package naming scheme (see slides)
+- `CPACK_DEBIAN_PACKAGE_SHLIBDEPS` tries to extract dependencies automatically. We can also set dependencies manually (`CPACK_DEBIAN_PACKAGE_DEPENDS`).
+- `cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Release ..` and `cpack -G DEB` ... no complaints
+- Different package name: `helloworld_0.1.0_amd64.deb`
+- Install the package: `sudo apt install ./helloworld_0.1.0_amd64.deb`
+- `helloworld` and `which helloworld`: now `/usr`, not `/usr/local`, since we use package manager.
 
-- Afterwards there will be no more complaint as the dependency list will be generated
+## Check Debian Package
+
+- Package is already usable. Still, one might want to check quality.
+    - If one wants to submit something to the actual repository of Ubuntu/Debian, then one has to follow standards.
+- Inspect meta information `dpkg --info helloworld_0.1.0_amd64.deb`
+- Check full content:
 
   ```bash
-  $ cpack -G DEB
-  CPack: Create package using DEB
-  CPack: Install projects
-  CPack: - Run preinstall target for: HelloWorld
-  CPack: - Install project: HelloWorld []
-  CPack: Create package
-  CPackDeb: - Generating dependency list
-  CPack: - package: /mnt/cpack-example/build/helloworld_0.1.0_amd64.deb generated.
+  dpkg-deb -R ./helloworld_0.1.0_amd64.deb ./helloworld-unpacked
+  tree helloworld-unpacked
   ```
 
-  We see that the package name was set to "${helloworld}" as lowercase names seem to be preferred.
-
-- We can install the package
-
-  ```bash
-  sudo apt install ./helloworld_0.1.0_amd64.deb
-  ```
-
-  Files are installed in `/usr` now instead of `/usr/local`. That is the default target for Debian packages using the generator!
-
-## 4. Check Debian package (Demo 2)
-
-- The package already is usable. However, one might want to make sure that quality is good. If one wants to submit something to the actual repository of Ubuntu/Debian, then one has to follow the provided standards.
-- If time permits we can checkout the contens of the package.
-    - Inspect meta information
-
-    ```bash
-    dpkg --info helloworld_0.1.0_amd64.deb
-    ```
-
-    - Check full content
-
-    ```bash
-    dpkg-deb -R ./helloworld_0.1.0_amd64.deb ./helloworld-unpacked
-    tree helloworld-unpacked
-    ./helloworld-unpacked/
-    ├── DEBIAN
-    │   ├── control
-    │   ├── md5sums
-    │   ├── postinst
-    │   └── postrm
-    └── usr
-        ├── bin
-        │   └── helloworld
-        ├── include
-        │   └── sse
-        │       └── sse.hpp
-        └── lib
-            ├── cmake
-            │   ├── HelloWorldTargets-release.cmake
-            │   └── HelloWorldTargets.cmake
-            ├── libsse.so -> libsse.so.0.1.0
-            └── libsse.so.0.1.0
-    ```
-
-
-- Check the package via `lintian`. (I need to do this on my host since I did not install lintian in the container).
-
-  ```bash
-  lintian helloworld_0.1.0_amd64.deb
-  ```
-
-- We observe quite some errors and warnings
-
-  ```bash
-  $ lintian helloworld_0.1.0_amd64.deb
-  E: helloworld: changelog-file-missing-in-native-package
-  E: helloworld: extended-description-is-empty
-  E: helloworld: maintainer-name-missing firstname.lastname@example.com
-  E: helloworld: no-copyright-file
-  E: helloworld: package-must-activate-ldconfig-trigger usr/lib/libsse.so
-  E: helloworld: unstripped-binary-or-object usr/bin/helloworld
-  E: helloworld: unstripped-binary-or-object usr/lib/libsse.so
-  W: helloworld: binary-without-manpage usr/bin/helloworld
-  W: helloworld: maintscript-calls-ldconfig postinst
-  W: helloworld: maintscript-calls-ldconfig postrm
-  W: helloworld: package-name-doesnt-match-sonames libsse
-  W: helloworld: shlib-without-versioned-soname usr/lib/libsse.so libsse.so
-  ```
-
-- Some things can be fixed easily by adding parameters to the CMake file
+- Check package via `lintian`: `lintian helloworld_0.1.0_amd64.deb`
+- Many errors and warning, some easy to fix:
 
   ```diff
   + set(CPACK_PACKAGE_CONTACT "SSE lecturers <firstname.lastname@example.com>")
+  # strip really all Debug symbols
   + set(CPACK_STRIP_FILES TRUE)
   ```
 
-  `CPACK_PACKAGE_CONTACT` was missing the name of the maintainer. `CPACK_STRIP_FILES` makes sure build files are stripped. For Debian packages the package maintainer can be set/overwritten with `CPACK_DEBIAN_PACKAGE_MAINTAINER`.
-
-  Besides that one can add a changelog and a copyright file.
-  `extended-description-is-empty` is requesting description of each component, i.e., the executable and the library. We do not provide information for each component at the moment.
-
-- For some points it is harder to fix them
-    - `package-must-activate-ldconfig-trigger`: Seems to be related how packages should be created and [CPack not respecting this yet](https://gitlab.kitware.com/cmake/cmake/-/issues/21834) (or I simply have an old version of CMake). CMake creates a maintainer script that calls `ldconfig` which should not be done anymore. Thus we get several error messages (1x ldconfig not called via trigger and 2x ldconfig called via maintainer script)
-    - `shlib-without-versioned-soname`: No versioning of our library (e.g., `libsse.so -> libsse.so.0.1.0`) thus `shlib` cannot safely determine dependencies for software depending our library.
+- Others harder to fix:
+    - `package-must-activate-ldconfig-trigger`: Seems to be related how packages should be created and [CPack not respecting this yet](https://gitlab.kitware.com/cmake/cmake/-/issues/21834). CMake creates a maintainer script that calls `ldconfig`, which should not be done anymore. Thus we get several error messages (1x ldconfig not called via trigger and 2x ldconfig called via maintainer script)

--- a/03_building_and_packaging/cpack_slides.md
+++ b/03_building_and_packaging/cpack_slides.md
@@ -24,7 +24,7 @@ slideOptions:
   }
   .reveal code {
     font-family: 'Source Code Pro';
-    color: orange;  
+    color: orange;
   }
 </style>
 
@@ -157,7 +157,7 @@ prefix/
 
 - Generate package
     - `cmake ..` and `cpack -G "TGZ;DEB"` or
-    - `make package` 
+    - `make package`
 - Set default
     - `set(CPACK_GENERATOR "TGZ;DEB")`
 

--- a/03_building_and_packaging/cpack_slides.md
+++ b/03_building_and_packaging/cpack_slides.md
@@ -41,18 +41,6 @@ slideOptions:
 
 ---
 
-## Introduction
-
-- Why [Debian](https://www.debian.org/) package format?
-    - It is common Debian, [Ubuntu](https://ubuntu.com/)...
-    - Is the "natural" way to insall software on Debian, Ubuntu etc. (via `dpkg`/aptitude `apt`)
-- Easy to share (`deb` file)
-- Can be hosted and integrated in [official](https://launchpad.net/ubuntu) or third-party repositories
-
-TODO: read more
-
----
-
 ## Step by Step Plan
 
 - Start from CMake configuration of previous lecture
@@ -214,7 +202,6 @@ prefix/
 - Contents (some optional):
     - `control` file: Name, dependencies etc.
     - `md5sum` or similar: Checksums of bundled files
-    - `conffile`: configuration file
     - Debian installation and removal scripts (`preinst`, `postinst`, `prerm`, `postrm`)
     - Files of actual package (binaries, libraries, includes...)
 
@@ -240,22 +227,11 @@ prefix/
 
 ---
 
-## Further Reading 1/2
+## Further Reading
 
 - [Debian Package Basics](https://www.debian.org/doc/manuals/debian-faq/pkg-basics.en.html)
-- [Debian Packaging Guide](https://wiki.debian.org/Packaging)
 - [Ubuntu Packaging Guide](https://packaging.ubuntu.com/html/)
 - [Launchpad](https://launchpad.net/)
-- [lintian reports](https://lintian.debian.org/)
-- [lintian man page](https://lintian.debian.org/)https://lintian.debian.org/
-
----
-
-## Further Reading 2/2
-
 - [CPack documentation](https://cmake.org/cmake/help/latest/module/CPack.html)
 - [List of CPack generators](https://cmake.org/cmake/help/latest/manual/cpack-generators.7.html)
-- [Debian CPack generator]([generators](https://cmake.org/cmake/help/latest/cpack_gen/deb.html#cpack_gen:CPack%20DEB%20Generator))
 - [Making a deb package with CMake/CPack and hosting it in a private APT repository](https://decovar.dev/blog/2021/09/23/cmake-cpack-package-deb-apt/)
-- [GNU coding standard](https://www.gnu.org/prep/standards/html_node/Directory-Variables.html)
-

--- a/03_building_and_packaging/examples/cpack/CMakeLists.txt
+++ b/03_building_and_packaging/examples/cpack/CMakeLists.txt
@@ -8,9 +8,9 @@ set_target_properties(sse PROPERTIES PUBLIC_HEADER sse/sse.hpp)
 # Set up library includes
 target_include_directories(sse
     PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/helloworld
+        ${CMAKE_CURRENT_SOURCE_DIR}
     PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/helloworld>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/helloworld>
 )
 

--- a/03_building_and_packaging/examples/cpack/CMakeLists.txt
+++ b/03_building_and_packaging/examples/cpack/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION "3.12")
+
+project("HelloWorld" VERSION 0.1.0)
+
+add_library(sse sse/sse.cpp)
+set_target_properties(sse PROPERTIES PUBLIC_HEADER sse/sse.hpp)
+
+# Set up library includes
+target_include_directories(sse
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/helloworld
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/helloworld>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/helloworld>
+)
+
+add_executable(helloworld main.cpp)
+target_link_libraries(helloworld PRIVATE sse)
+
+# Create install targets
+include(GNUInstallDirs)
+install(TARGETS helloworld sse
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/helloworld
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/helloworld
+  )

--- a/03_building_and_packaging/examples/cpack/Dockerfile
+++ b/03_building_and_packaging/examples/cpack/Dockerfile
@@ -1,0 +1,21 @@
+From ubuntu:22.04
+
+COPY inittimezone /usr/local/bin/inittimezone
+
+# Run inittimezone and install a few dependencies
+RUN apt-get -qq update && \
+    inittimezone && \
+    apt-get -qq -y install \
+        build-essential \
+	cmake \
+        g++ \
+        vim \
+	tree \
+	lintian
+
+# This is some strang Docker problem. Normally, you don't need to add /usr/local/lib to LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH $LD_LIBRARY_PATH:/usr/local/lib/
+
+
+ADD . /helloworld
+CMD ["/bin/bash"]

--- a/03_building_and_packaging/examples/cpack/cmake/CPackConfig.cmake
+++ b/03_building_and_packaging/examples/cpack/cmake/CPackConfig.cmake
@@ -1,0 +1,11 @@
+set(CPACK_PACKAGE_NAME ${PROJECT_NAME})
+
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "SSE hello world example project"
+  CACHE STRING "Extended summary.")
+
+set(CPACK_PACKAGE_VENDOR "SSE Lecturers")
+set(CPACK_PACKAGE_CONTACT "firstname.lastname@example.com")
+set(CPACK_PACKAGE_MAINTAINERS "SSE lecturers ${CPACK_PACKAGE_CONTACT}")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://simulation-software-engineering.github.io")
+
+include(CPack)

--- a/03_building_and_packaging/examples/cpack/inittimezone
+++ b/03_building_and_packaging/examples/cpack/inittimezone
@@ -1,0 +1,16 @@
+#! /bin/sh
+#
+# initialized the timezone and localtime
+#
+# This is required to prevent debconf to query the information when installing tzdata
+#
+
+if [ -e /etc/timezone -o -e /etc/localtime ]; then
+  echo "Timezone already initalized"
+  exit 0
+fi
+
+export TZ=Europe/Berlin
+echo $TZ > /etc/timezone
+ln -snf /usr/share/zoneinfo/$TZ /etc/localtime
+exit 0

--- a/03_building_and_packaging/examples/cpack/main.cpp
+++ b/03_building_and_packaging/examples/cpack/main.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+
+#include "sse/sse.hpp"
+
+int main(int argc, char *argv[])
+{
+  std::cout << "Hello World!" << std::endl;
+  sse();
+  return 0;
+}

--- a/03_building_and_packaging/examples/cpack/sse/sse.cpp
+++ b/03_building_and_packaging/examples/cpack/sse/sse.cpp
@@ -1,0 +1,7 @@
+#include "sse.hpp"
+#include <iostream>
+
+void sse()
+{
+  std::cout << "SSE is great!" << std::endl;
+}

--- a/03_building_and_packaging/examples/cpack/sse/sse.hpp
+++ b/03_building_and_packaging/examples/cpack/sse/sse.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+void sse();

--- a/timetable.md
+++ b/timetable.md
@@ -65,3 +65,8 @@
 ## 6.2 – Thu, November 24, 2022
 
 - **90** [Exercise: Let's Fight With CMake, Docker, and Some Dependencies](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/cmake_exercise.md)
+
+## 7.1 – Thu, December 1, 2022
+
+- **70** Installation and Packaging with CMake and CPack: [slides](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/cpack_slides.md), [demo](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/cpack_demo.md)
+- **20** More CMake Demo (preCICE and ccmake): [demo](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/cmake_more_demo.md)


### PR DESCRIPTION
## Description

Update CPack lecture:

- Rewrote and re-organized demo notes
- Moved example code from [separate repo](https://github.com/Simulation-Software-Engineering/HelloWorld) to `examples/cpack`
- Added a misc part "more cmake demo" to show preCICE things and ccmake

Fixes #63

## Checklist

<!--- Please make sure to go over all points on the checklist and mark them as checked. -->

- [x] I made sure that the markdown files are formatted properly.
- [ ] I made sure that all hyperlinks are working.

<!-- If the pull request adds new content, please check the points below. Otherwise remove the following lines. -->

- [x] I added the new content to the `README.md` inside the topics subdirectory, e.g., `01_version_control/README.md`.
- [x] I added the new content to the `timetable.md` in the root of this repository.
