### PR TITLE
fix(building/cpack_slides): Fix path for target include dir

### DIFF
--- a/03_building_and_packaging/cpack_slides.md
+++ b/03_building_and_packaging/cpack_slides.md
@@ -79,7 +79,7 @@ prefix/
           ${CMAKE_CURRENT_SOURCE_DIR}/includedir
       PUBLIC
           # where top-level project will look for the library's public headers
-          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/includedir>
+          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
           # where external projects will look for the library's public headers
           $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/includedir>
   )


### PR DESCRIPTION

## Description

Fix the path for the target include dir for the top level project.
For the top-level project the source dir is used.
This should usually not be suffixed with a includedir, as the headers are spread across the source subfolders.


## Checklist

<!--- Please make sure to go over all points on the checklist and mark them as checked. -->

- [x] I made sure that the markdown files are formatted properly.
- [x] ~~I made sure that all hyperlinks are working.~~
