### PR TITLE
Fix broken link to repository_layouts_slides.md

### DIFF
--- a/06_miscellaneous/README.md
+++ b/06_miscellaneous/README.md
@@ -9,6 +9,6 @@ Learning goals:
 | 20 minutes | [doi_zenodo_darus_slides.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/06_miscellaneous/doi_zenodo_darus_slides.md) |
 | 20 minutes | [floss_licenses_slides.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/06_miscellaneous/floss_licenses_slides.md) |
 | 20 minutes | [versioning_slides.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/06_miscellaneous/versioning_slides.md) |
-| 20 minutes | [repository_layouts_slides.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/06_miscellaneous/repository_layout_slides.md) |
+| 20 minutes | [repository_layouts_slides.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/06_miscellaneous/repository_layouts_slides.md) |
 | 20 minutes | [tools_alex_slides.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/06_miscellaneous/tools_alex_slides.md), [tools_alex_demo.md](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/06_miscellaneous/tools_alex_demo.md) |
 


### PR DESCRIPTION
## Description

The link to the **repository_layouts_slides.md** in the readme was broken.

## Checklist

<!--- Please make sure to go over all points on the checklist and mark them as checked. -->

- [ x] I made sure that the markdown files are formatted properly.
- [ x] I made sure that all hyperlinks are working.

<!-- If the pull request adds new content, please check the points below. Otherwise remove the following lines. -->

- [x ] I added the new content to the `README.md` inside the topics subdirectory `06_miscellaneous/README.md`.
- ~~[ ] I added the new content to the `timetable.md` in the root of this repository.~~
