### PR TITLE
Fix link to exercise repository in boost testing exercise

### DIFF
--- a/05_testing_and_ci/boost_testing_exercise.md
+++ b/05_testing_and_ci/boost_testing_exercise.md
@@ -7,7 +7,7 @@ Deadline: **Thursday, February 9th, 2023, 09:00**
 ## Preparation and Submission
 
 
-- Import the [testing boost exercise repository](https://github.com/Simulation-Software-Engineering/testing-boost-exercise) in your own account/namespace on GitHub and name it `testing-boost-exercise` again. **Note**: We cannot work with forks here because GitHub Actions may not work in pull requests without explicit approval of the owner of the target repository
+- Import the [testing boost exercise repository](https://github.com/Simulation-Software-Engineering/testing-boost-exercise-wt2223) in your own account/namespace on GitHub and name it `testing-boost-exercise` again. **Note**: We cannot work with forks here because GitHub Actions may not work in pull requests without explicit approval of the owner of the target repository
 - Create a new branch `extend-tests` from `main` and work in this branch.
 - To submit, open a PR from `extend-tests` to `main` in your own repository. Then paste a link to this PR in a new issue in the original repository. Use `[GITLAB-USERNAME] Boost test exercise` as title of the issue.
 


### PR DESCRIPTION
## Description

Fix the link "[testing boost exercise repository](https://github.com/Simulation-Software-Engineering/testing-boost-exercise-wt2223)" in the boost testing exercise sheet

## Checklist

<!--- Please make sure to go over all points on the checklist and mark them as checked. -->

- [x] I made sure that the markdown files are formatted properly.
- [x] I made sure that all hyperlinks are working.
