### PR TITLE
Fix CI: Pin versions, tidy up upload-artifact calls

### DIFF
--- a/.github/workflows/create-pdfs-from-markdown.yml
+++ b/.github/workflows/create-pdfs-from-markdown.yml
@@ -21,7 +21,8 @@ jobs:
       - name: Compile PDFs (slides)
         run: |
           ./scripts/create-pdf-from-markdown.sh slides
-      - uses: actions/upload-artifact@master
+      - name: Upload slides
+        uses: actions/upload-artifact@master
         with:
           name: slides
           path: slides
@@ -35,7 +36,8 @@ jobs:
       - name: Compile PDFs (demos)
         run: |
           ./scripts/create-pdf-from-markdown.sh demo
-      - uses: actions/upload-artifact@master
+      - name: Upload texts
+        uses: actions/upload-artifact@master
         with:
           name: texts
           path: texts

--- a/.github/workflows/create-pdfs-from-markdown.yml
+++ b/.github/workflows/create-pdfs-from-markdown.yml
@@ -29,19 +29,9 @@ jobs:
       - name: Compile PDFs (quizzes)
         run: |
           ./scripts/create-pdf-from-markdown.sh quiz
-      - uses: actions/upload-artifact@master
-        with:
-          name: texts
-          path: texts
-          retention-days: 7
       - name: Compile PDFs (exercises)
         run: |
           ./scripts/create-pdf-from-markdown.sh exercise
-      - uses: actions/upload-artifact@master
-        with:
-          name: texts
-          path: texts
-          retention-days: 7
       - name: Compile PDFs (demos)
         run: |
           ./scripts/create-pdf-from-markdown.sh demo

--- a/.github/workflows/create-pdfs-from-markdown.yml
+++ b/.github/workflows/create-pdfs-from-markdown.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   create_pdfs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: pandoc/latex:latest
     steps:
       - name: Install bash

--- a/.github/workflows/create-pdfs-from-markdown.yml
+++ b/.github/workflows/create-pdfs-from-markdown.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   create_pdfs:
     runs-on: ubuntu-22.04
-    container: pandoc/latex:latest
+    container: pandoc/latex:2
     steps:
       - name: Install bash
         run: apk add bash

--- a/01_version_control/git_basics_demo.md
+++ b/01_version_control/git_basics_demo.md
@@ -9,7 +9,7 @@
     - Maintainer: rebase, squash, cherry-pick, bisect
     - Owner: submodules
 
-![git overview picture from py-rse](https://merely-useful.tech/py-rse/figures/git-cmdline/git-remote.png)
+![git overview picture from py-rse](https://third-bit.com/py-rse/figures/git-cmdline/git-remote.png)
 
 - `git --help`, `git commit --help`
 - incomplete statement `git comm`


### PR DESCRIPTION
## Description

- Pins the `pandoc/latex` version to 2 -> Fixes the `undefined ref` issue, triggered in version 3. Not sure if it is worth investing more effort here.
- Bumps the runner version to 22.04 (could even be `latest`), as the 20.04 should anyway be EOL.
- Fixes an image URL that returned 404.
- Removes duplicate calls to `upload-artifacts` and names the remaining two (slides and texts)

This can be merged as-is, without squashing.

## Checklist

<!--- Please make sure to go over all points on the checklist and mark them as checked. -->

- I made sure that the markdown files are formatted properly. -> N/A
- [x] I made sure that all hyperlinks are working.

<!-- If the pull request adds new content, please check the points below. Otherwise, remove the following lines. -->

- I added the new content to the `README.md` inside the topics subdirectory, e.g., `01_version_control/README.md`. -> N/A
- I added the new content to the `timetable.md` in the root of this repository. -> N/A

Please check that the uploaded artifacts are as intended.
