### PR TITLE
Convert plain text path docs/styleguide.md to a Markdown link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ We appreciate all kinds of contributions to this project. This document gives yo
 
 ## Style
 
-Please follow the guidelines in `docs/styleguide.md`.
+Please follow the guidelines in [docs/styleguide.md](docs/styleguide.md).
 
 ## Licensing of Contributed Material
 


### PR DESCRIPTION
## Description

<!--- Please describe shortly what this pull request is doing. If there is a related issue, please mention it here. -->
Convert plain text path docs/styleguide.md to a Markdown link [docs/styleguide.md](docs/styleguide.md) so it’s clickable in viewers. 

## Checklist

<!--- Please make sure to go over all points on the checklist and mark them as checked. -->

- [x] I made sure that the markdown files are formatted properly.
- [x] I made sure that all hyperlinks are working.
