### PR TITLE
Fix spelling error from typs to types in subtopic Advanced Topics

### DIFF
--- a/02_virtualization_and_containers/docker_slides.md
+++ b/02_virtualization_and_containers/docker_slides.md
@@ -255,7 +255,7 @@ Details available in [`docker_demo.md`](https://github.com/Simulation-Software-E
 - User ID mapping
 - [Multistage builds](https://docs.docker.com/develop/develop-images/multistage-build/)
     - Build image by combining layers created from different base images
-- [Different mount typs](https://docs.docker.com/storage)
+- [Different mount types](https://docs.docker.com/storage)
     - Volumes, bind mount, tmpfs mount
 - [Persisting data](https://docs.docker.com/get-started/05_persisting_data/)
 - [Multi-container apps](https://docs.docker.com/get-started/07_multi_container/)


### PR DESCRIPTION
## Description

<!--- Please describe shortly what this pull request is doing. If there is a related issue, please mention it here. -->

## Checklist

<!--- Please make sure to go over all points on the checklist and mark them as checked. -->

- [x] I made sure that the markdown files are formatted properly.
- [x] I made sure that all hyperlinks are working.

<!-- If the pull request adds new content, please check the points below. Otherwise, remove the following lines. -->

- [ ] I added the new content to the `README.md` inside the topics subdirectory, e.g., `01_version_control/README.md`.
- [ ] I added the new content to the `timetable.md` in the root of this repository.
