### PR TITLE
Remove non-existent lecture slide links

### DIFF
--- a/02_virtualization_and_containers/README.md
+++ b/02_virtualization_and_containers/README.md
@@ -9,7 +9,6 @@ Learning goals:
 
 | Duration | Content |
 | --- | --- |
-| 10 minutes | [`containers_slides.md`](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/02_virtualization_and_containers/containers_slides.md), [`containers_demo.md`](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/02_virtualization_and_containers/containers_demo.md) |
 | 65 minutes | [`docker_slides.md`](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/02_virtualization_and_containers/docker_slides.md), [`docker_demo.md`](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/02_virtualization_and_containers/docker_demo.md) |
 | 5 minutes | [`intro_slides.md`](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/02_virtualization_and_containers/intro_slides.md) |
 | 20 minutes | [`singularity_slides.md`](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/02_virtualization_and_containers/singularity_slides.md), [`singularity_demo.md`](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/02_virtualization_and_containers/singularity_demo.md) |


### PR DESCRIPTION
## Description
The hyperlinks to the lecture slides `containers_demo.md` and `containers_slides.md` are not valid/ not found anymore, seeing that the corresponding files are not inside the `02_virtualization_and_containers` repository.

## Checklist
- [x] I made sure that the markdown files are formatted properly.
- [x] I made sure that all hyperlinks are working. - indeed :)

<!-- If the pull request adds new content, please check the points below. Otherwise, remove the following lines. -->

- [ ] I added the new content to the `README.md` inside the topics subdirectory, e.g., `01_version_control/README.md`.
- [x] I ~added the new~ removed content ~to~ from the `timetable.md` in the root of this repository.

> [!NOTE]
> Perhaps the timetable is currently being modified by the maintainers, which leads to the invalid links. In that case, this PR is not relevant, as changes are underway.
