### PR TITLE
Update virtualmachines_containers_exercise.md to include missing run statement for fastfetch

### DIFF
--- a/02_virtualization_and_containers/virtualmachines_containers_exercise.md
+++ b/02_virtualization_and_containers/virtualmachines_containers_exercise.md
@@ -152,6 +152,7 @@ Let's install `fastfetch` from the community repositories, instead:
 - Enable the community repositories with `setup-apkrepos -c` and use the default settings
 - Update the cache with `apk update`
 - Install fastfetch with `apk add fastfetch`
+- Run fastfetch with `fastfetch`
 
 Continue to step 5.
 


### PR DESCRIPTION
## Description

Just noticed the statement to execute fastfetch was missing in the tutorial

## Checklist

I will skip the checklist below, since my proposed changes do not impact any of the expected checks.

- [x] I made sure that the markdown files are formatted properly.
- [x] I made sure that all hyperlinks are working.
