### PR TITLE
Clarify COPY and ADD command descriptions

### DIFF
--- a/02_virtualization_and_containers/docker_slides.md
+++ b/02_virtualization_and_containers/docker_slides.md
@@ -200,8 +200,8 @@ Details available in [`docker_demo.md`](https://github.com/Simulation-Software-E
 - `FROM`: Defines base image
 - `RUN`: Defines commands to execute
 - `WORKDIR`: Defines working directory for following commands
-- `COPY`: Copy for from source to destination
-- `ADD`: Add for from source to destination (powerful and confusing)
+- `COPY`: Copy file from source to destination
+- `ADD`: Add file from source to destination (powerful and confusing)
 - `CMD`: Command to run under `docker run`
 - `ENV`: Sets environment variable
 - `ARG`: Environment variable for **only** the build process


### PR DESCRIPTION
## Description

Fix minor `for` instead of `file` typo in description of `COPY` and `ADD` functionality.

## Checklist

- [x] I made sure that the markdown files are formatted properly.
- [x] I made sure that all hyperlinks are working.
