### PR TITLE
Fix typo in docker_demo.md container name

### DIFF
--- a/02_virtualization_and_containers/docker_demo.md
+++ b/02_virtualization_and_containers/docker_demo.md
@@ -23,7 +23,7 @@
 - We can make sure that the container is removed after exiting by the `--rm` options, i.e., `docker run --rm -i -t ubuntu /bin/bash`
 
 - When container is running, we see it when calling `docker ps`
-- Start container (with name `tutoral`) `docker run --rm -i -t --name tutorial ubuntu    /bin/bash`
+- Start container (with name `tutorial`) `docker run --rm -i -t --name tutorial ubuntu    /bin/bash`
 - Leave it `CTRL-P-Q` (all keys pressed at the same time)
 - Show container running `docker ps`
 - Reattach to container `docker container attach tutorial`


### PR DESCRIPTION
## Description

Fix minor typo from `tutoral` to `tutorial`.

## Checklist

- [x] I made sure that the markdown files are formatted properly.
- [x] I made sure that all hyperlinks are working.
