### PR TITLE
Update demo link for Packaging a Python Code

### DIFF
--- a/timetable.md
+++ b/timetable.md
@@ -49,7 +49,7 @@
 ## 5.1 – Wed, November 12, 2025
 
 - **15** min.: [Introduction to Packaging](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/intro_slides.md)
-- **75** min.: Packaging a Python Code: [demo](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/pypi_demo.md), [slides](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/pypi_slides.md)
+- **75** min.: Packaging a Python Code: [demo](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/pip_demo.md), [slides](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/03_building_and_packaging/pypi_slides.md)
 
 ## 5.2 – Wed, November 12, 2025
 


### PR DESCRIPTION
The link to the "Packaging a Python Code" demo was leading to a non-existent file. Perhaps, now the proposed link in this PR is the correct demo file.

## Description

This PR replaces a non-existent link to the `pypi_demo` with an existing one to the `pip_demo`.

## Checklist

- [x] I made sure that the markdown files are formatted properly.
- [x] I made sure that all hyperlinks are working.
