### PR TITLE
Fix minor formatting in spack_slides.md

### DIFF
--- a/03_building_and_packaging/spack_slides.md
+++ b/03_building_and_packaging/spack_slides.md
@@ -350,7 +350,7 @@ slideOptions:
 - Popular package managers for HPC.
     - [Spack](https://spack.io/)
         - ... originates from LLNL in the US.
-        - .. is built around concretizer.
+        - ... is built around concretizer.
     - [EasyBuild](https://github.com/easybuilders/easybuild)
         - ... originates from Ghent University in Belgium.
 - Both suitable for users, admins, researchers.


### PR DESCRIPTION
## Description

Added a missing full stop in the ellipsis.

## Checklist

- [x] I made sure that the markdown files are formatted properly.
- [x] I made sure that all hyperlinks are working.
