### PR TITLE
Improve troubleshooting information of python testing exercise

### DIFF
--- a/05_testing_and_ci/python_testing_exercise.md
+++ b/05_testing_and_ci/python_testing_exercise.md
@@ -45,7 +45,7 @@
     - Note that you have the object of the class `SolveDiffusion2D` and hence you can access member variables, for example `solver.nx` and `solver.ny`. This is useful to check the actual values.
 - Using a similar workflow, complete the other two unit tests.
 - **Troubleshooting:**
-    - If pytest is not able to locate the `diffusion2d` module, try `python3 -m pytest` instead to add the current directory to `sys.path`, see [documentation](https://docs.pytest.org/en/stable/how-to/usage.html). 
+    - If pytest is not able to locate the `diffusion2d` module, try `python3 -m pytest` instead to add the current directory to `sys.path`, see [documentation](https://docs.pytest.org/en/stable/how-to/usage.html).
     - Sometimes pytest is not able to find the tests. One reason is the way pytest is installed, which is typically either using pip or apt. Refer to the [corresponding section](https://github.com/Simulation-Software-Engineering/Lecture-Material/blob/main/05_testing_and_ci/python_testing_demo.md#pytest) in the demo for more details. If such errors occur, then try to explicitly point pytest to the relevant test file in the following way:
 
 ```bash


### PR DESCRIPTION
Added troubleshooting tips for pytest module location issues.

- I and some others hat issues because of `ModuleNotFound` errors after installing pytest.
- Added the hint form the documentation about adding the current directory to `sys.path`.

<!--- Please describe shortly what this pull request is doing. If there is a related issue, please mention it here. -->

## Checklist

<!--- Please make sure to go over all points on the checklist and mark them as checked. -->

- [x] I made sure that the markdown files are formatted properly.
- [x] I made sure that all hyperlinks are working.

<!-- If the pull request adds new content, please check the points below. Otherwise, remove the following lines. -->

- [ ] I added the new content to the `README.md` inside the topics subdirectory, e.g., `01_version_control/README.md`.
- [ ] I added the new content to the `timetable.md` in the root of this repository.
