### PR TITLE
Updated repo link in gitlab ci demo slides to 2526 semester

### DIFF
--- a/05_testing_and_ci/gitlab_ci_demo.md
+++ b/05_testing_and_ci/gitlab_ci_demo.md
@@ -1,6 +1,6 @@
 # Demo: GitLab Runner
 
-Test code in [automation lecture repository](https://gitlab-sim.informatik.uni-stuttgart.de/simulation-software-engineering-wite2425/lecture-automation) on our GitLab instance
+Test code in [automation lecture repository](https://gitlab-sim.informatik.uni-stuttgart.de/simulation-software-engineering-wite2526/lecture-automation) on our GitLab instance
 
 ## Inspect Repository
 


### PR DESCRIPTION
## Description

The **Demo: GitLab Runner**  slides were pointing to old semester link which is not accessible. 
I change the link to https://gitlab-sim.informatik.uni-stuttgart.de/simulation-software-engineering-wite2526/lecture-automation

## Checklist

<!--- Please make sure to go over all points on the checklist and mark them as checked. -->

- [X] I made sure that the markdown files are formatted properly.
- [X] I made sure that all hyperlinks are working.


