### PR TITLE
Add a CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 cff-version: 1.2.0
-message: "If you use this course material, please cite the respective presentation about it. We are working on a publication about it."
+message: "If you use this course material, please cite the respective presentation about it. We are working on a full publication."
 authors:
 - family-names: "Uekermann"
   given-names: "Benjamin"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,7 +16,7 @@ authors:
 title: "Simulation Software Engineering Lecture Material"
 doi: 10.18419/DARUS-6463
 version: v202602.0
-date-released: 2026-03-01
+date-released: 2026-02-05
 url: "https://github.com/Simulation-Software-Engineering/Lecture-Material"
 preferred-citation:
   title: "Four years of experience teaching Simulation Software Engineering"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,6 +14,8 @@ authors:
   given-names: "Gerasimos"
   orcid: "https://orcid.org/0000-0002-3977-1385"
 title: "Simulation Software Engineering Lecture Material"
+doi: 10.18419/DARUS-6463
+version: v202602.0
 date-released: 2026-03-01
 url: "https://github.com/Simulation-Software-Engineering/Lecture-Material"
 preferred-citation:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,38 @@
+cff-version: 1.2.0
+message: "If you use this course material, please cite the respective presentation about it. We are working on a publication about it."
+authors:
+- family-names: "Uekermann"
+  given-names: "Benjamin"
+  orcid: "https://orcid.org/0000-0002-1314-9969"
+- family-names: "Desai"
+  given-names: "Ishaan"
+  orcid: "https://orcid.org/0000-0002-2552-7509"
+- family-names: "Jaust"
+  given-names: "Alexander"
+  orcid: "https://orcid.org/0000-0002-6082-105X"
+- family-names: "Chourdakis"
+  given-names: "Gerasimos"
+  orcid: "https://orcid.org/0000-0002-3977-1385"
+title: "Simulation Software Engineering Lecture Material"
+version: 1.0.0
+doi: 10.5281/zenodo.18823855
+date-released: 2026-03-01
+url: "https://github.com/Simulation-Software-Engineering/Lecture-Material"
+preferred-citation:
+  title: "Four years of experience teaching Simulation Software Engineering"
+  type: article
+  conference:
+    name: "deRSE26 - 6th conference for Research Software Engineering in Germany"
+  authors:
+  - family-names: "Uekermann"
+    given-names: "Benjamin"
+    orcid: "https://orcid.org/0000-0002-1314-9969"
+  - family-names: "Desai"
+    given-names: "Ishaan"
+    orcid: "https://orcid.org/0000-0002-2552-7509"
+  - family-names: "Jaust"
+    given-names: "Alexander"
+    orcid: "https://orcid.org/0000-0002-6082-105X"
+  - family-names: "Chourdakis"
+    given-names: "Gerasimos"
+    orcid: "https://orcid.org/0000-0002-3977-1385"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,13 +14,13 @@ authors:
   given-names: "Gerasimos"
   orcid: "https://orcid.org/0000-0002-3977-1385"
 title: "Simulation Software Engineering Lecture Material"
-version: 1.0.0
-doi: 10.5281/zenodo.18823855
 date-released: 2026-03-01
 url: "https://github.com/Simulation-Software-Engineering/Lecture-Material"
 preferred-citation:
   title: "Four years of experience teaching Simulation Software Engineering"
   type: article
+  doi: 10.5281/zenodo.18823855
+  version: v1
   conference:
     name: "deRSE26 - 6th conference for Research Software Engineering in Germany"
   authors:


### PR DESCRIPTION
As suggested by @uekerman, this points to https://doi.org/10.5281/zenodo.18823855, until we have a proper publication of the material.

The file passes [validation](https://github.com/citation-file-format/citation-file-format/tree/main#validation-heavy_check_mark). I had to use `type: article` for the `preferred-citation` (`presentation` was not accepted).

Schema: https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md