### PR TITLE
Port the GitLab-Runner instructions from bw-cloud (Gen2) to bwCloud-OS (Gen3)

### DIFF
--- a/05_testing_and_ci/automation_exercise.md
+++ b/05_testing_and_ci/automation_exercise.md
@@ -33,5 +33,5 @@ Once the workflow runs successfully, add a [GitHub workflow status badge](https:
 Realize the same workflows in GitLab CI/CD :)
 
 - Create a new project under your namespace and push your existing automation repository to this remote.
-- Create a VM on [bwCloud](https://www.bw-cloud.org/) and create a GitLab Runner with a Docker executor there. Register the runner in your repository.
+- Create a VM on [bwCloud-OS](https://bwcloud-os.de/) and create a GitLab Runner with a Docker executor there. Register the runner in your repository.
 - Add a link to this repository in the submission issue above and, if necessary, explain what you did. Be sure that your repository is visible to us (either public or add `gchourdakis`).

--- a/05_testing_and_ci/gitlab_ci_demo.md
+++ b/05_testing_and_ci/gitlab_ci_demo.md
@@ -16,10 +16,10 @@ Test code in [automation lecture repository](https://gitlab-sim.informatik.uni-s
     - URL and Token; we will need this in a minute
     - Select `Run untagged jobs`
 
-## Inspect bwCloud
+## Inspect bwCloud-OS
 
-- bwCloud: many services academia in BW can use; e.g. VMs
-- Go to dashboard: https://portal.bw-cloud.org/ and login with Uni Stuttgart account
+- bwCloud-OS: many services academia in BW can use; e.g. VMs
+- Go to dashboard: https://bwcloud-os.de/ and login with Uni Stuttgart account
 - I have already set up a VM. What I did:
     - Add public SSH key
     - Instances -> Launch instance
@@ -29,7 +29,7 @@ Test code in [automation lecture repository](https://gitlab-sim.informatik.uni-s
 - Apply updates: `sudo apt update && sudo apt -y upgrade`
 - Install Docker: `sudo apt install -y docker.io`
 
-You can get the IP from the [Instances view](https://portal.bw-cloud.org/project/instances/). Note that there are two addresses here: an IPv4 (decimal) and an IPv6 (hexadecimal) address. New VMs on bwCloud only support IPv6 networks, so you need the second address.
+You can get the IP from the Instances view (`project/instances/`). Note that there are two addresses here: an IPv4 (decimal) and an IPv6 (hexadecimal) address. VMs on bwCloud-OS only support IPv6 networks, so you need the second address.
 
 ## Setup GitLab Runner
 
@@ -57,7 +57,7 @@ You can get the IP from the [Instances view](https://portal.bw-cloud.org/project
 
 ## Register Runner
 
-You can register a runner using the following command. Notice again the `--network host` option, which tells Docker to use the host network stack. This is an important workaround for the fact that bwCloud only supports IPv6 networks:
+You can register a runner using the following command. Notice again the `--network host` option, which tells Docker to use the host network stack. This is an important workaround for the fact that bwCloud-OS only supports IPv6 networks:
 
 ```bash
 sudo docker run --rm -it \
@@ -85,7 +85,7 @@ sudo docker run --rm -it \
 
 ## Workarounds for IPv6
 
-New bwCloud VMs only support IPv6 by default. Asking for IPv4 for a specific VM might be possible via the [helpdesk](https://bw-support.scc.kit.edu/). A few workarounds are needed to make the GitLab runner work in this IPv6-only environment.
+VMs on bwCloud-OS only support IPv6 by default. Asking for IPv4 for a specific VM might be possible via the [helpdesk](https://bw-support.scc.kit.edu/). A few workarounds are needed to make the GitLab runner work in this IPv6-only environment.
 
 First, we need to start Docker with `-e GODEBUG="netdns=go+ipv6"`. This is related to Go prioritizing IPv4 connections.
 

--- a/05_testing_and_ci/gitlab_ci_demo.md
+++ b/05_testing_and_ci/gitlab_ci_demo.md
@@ -23,11 +23,11 @@ Test code in [automation lecture repository](https://gitlab-sim.informatik.uni-s
     - Not to be confused with the previous phase of the project (Gen2), under the `bw-cloud.org` domain name. The current service is the continuation of that (Gen3).
 - Go to dashboard: https://bwcloud-os.de/ and login with Uni Stuttgart account
 - I have already set up a VM. What I did:
-    - Add public SSH key
+    - Added a [public SSH key](https://docs.gitlab.com/user/ssh/#generate-an-ssh-key-pair)
     - Instances -> Launch instance
-        - Ubuntu 24.04
-        - Flavor: m1.small
-- VM is up and running, connect to it: `ssh ubuntu@<IPv6>`
+        - Source: Ubuntu 26.04
+        - Flavor: p1.nano (1 vCPU, 1GB RAM, according to the student quota)
+- VM is up and running, connect to it: `ssh ubuntu@<IPv6>` (you need to be in the university network - see [TIK VPN](https://www.tik.uni-stuttgart.de/en/services-a-z/VPN/))
 - Apply updates: `sudo apt update && sudo apt -y upgrade`
 - Install Docker: `sudo apt install -y docker.io`
 
@@ -74,10 +74,8 @@ sudo docker run --rm -it \
     - URL: (press Enter to confirm)
     - Token: see above
     - Name/Description: `SSE Automation Demo Runner`
-    - No tags, no maintenance note
     - Executor: `docker`
     - Default Docker image: `alpine:latest` (used for pipelines that do not specify any Docker image themselves, can be overwritten in configuration of pipeline)
-- `sudo vi /srv/gitlab-runner/config/config.toml`
 - Verify that there is now a runner in the repo settings
 - Verify that pipeline now ran
 
@@ -91,7 +89,7 @@ VMs on bwCloud-OS only support IPv6 by default. Asking for IPv4 for a specific V
 
 First, we need to start Docker with `-e GODEBUG="netdns=go+ipv6"`. This is related to Go prioritizing IPv4 connections.
 
-We also need to tell Docker to use the host network stack. We also need to replace the helper image with [the one from Docker Hub](https://hub.docker.com/r/gitlab/gitlab-runner-helper) (tag depends on the GitLab version, e.g., [x86_64-v18.8.0](https://hub.docker.com/layers/gitlab/gitlab-runner-helper/x86_64-v18.8.0/images/sha256-9b95c50a9b4b49dd5be9ea9e2191164b649f33f94cc81886a517e846ae4096ee)), since [`registry.gitlab.com` does not support IPv6](https://gitlab.com/gitlab-com/gl-infra/production-engineering/-/issues/18058). You can start without this setting, and see which image GitLab is trying to pull). Edit the `[runners.docker]` section in `/srv/gitlab-runner/config/config.toml`:
+We also need to tell Docker to use the host network stack. We also need to replace the helper image with [the one from Docker Hub](https://hub.docker.com/r/gitlab/gitlab-runner-helper) (tag depends on the GitLab version, e.g., [x86_64-v18.8.0](https://hub.docker.com/layers/gitlab/gitlab-runner-helper/x86_64-v18.8.0/images/sha256-9b95c50a9b4b49dd5be9ea9e2191164b649f33f94cc81886a517e846ae4096ee)), since [`registry.gitlab.com` does not support IPv6](https://gitlab.com/gitlab-com/gl-infra/production-engineering/-/issues/18058). You can start without this setting, and see which image GitLab is trying to pull. Edit the `[runners.docker]` section in `/srv/gitlab-runner/config/config.toml`:
 
 ```toml
   helper_image = "gitlab/gitlab-runner-helper:x86_64-v18.8.0"
@@ -99,4 +97,3 @@ We also need to tell Docker to use the host network stack. We also need to repla
 ```
 
 While we already pass `--network host` to `docker run`, setting this system-wide makes it easier to also start the job containers with the same settings.
-

--- a/05_testing_and_ci/gitlab_ci_demo.md
+++ b/05_testing_and_ci/gitlab_ci_demo.md
@@ -19,6 +19,8 @@ Test code in [automation lecture repository](https://gitlab-sim.informatik.uni-s
 ## Inspect bwCloud-OS
 
 - bwCloud-OS: many services academia in BW can use; e.g. VMs
+    - Our university provides the service to all students and employees, under specific quotas. Students get one VM instance. See the [TIK page](https://www.tik.uni-stuttgart.de/dienste-a-z/bwCloud/).
+    - Not to be confused with the previous phase of the project (Gen2), under the `bw-cloud.org` domain name. The current service is the continuation of that (Gen3).
 - Go to dashboard: https://bwcloud-os.de/ and login with Uni Stuttgart account
 - I have already set up a VM. What I did:
     - Add public SSH key

--- a/05_testing_and_ci/gitlab_ci_slides.md
+++ b/05_testing_and_ci/gitlab_ci_slides.md
@@ -182,7 +182,7 @@ deploy job:
 
 ## Demo: GitLab Runner
 
-- Installation of a GitLab Runner on a [bwCloud](https://portal.bw-cloud.org/) VM (via Docker)
+- Installation of a GitLab Runner on a [bwCloud-OS](https://bwcloud-os.de/) VM (via Docker)
 - Registration of the runner to a repository (Docker as executor)
 
 ---


### PR DESCRIPTION
## Description

closes #261.

I have so far only registered runners for my projects. GitLab projects for SSE 2026-27 do not exist yet. I would register the same runner again.

## Checklist

<!--- Please make sure to go over all points on the checklist and mark them as checked. -->

- [x] I made sure that the markdown files are formatted properly.
- [x] I made sure that all hyperlinks are working.